### PR TITLE
Added respawn logic for player.gd

### DIFF
--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -24,6 +24,9 @@ extends JPlayerBody2D
 	"LeftHand": $Sprites/LeftHand.texture
 }
 
+var death_popup_instance = load("res://scenes/player/deathpopup/DeathPopup.tscn").instantiate()
+#var died_a #for testing
+
 
 func _ready():
 	synchronizer.loop_animation_changed.connect(_on_loop_animation_changed)
@@ -32,6 +35,8 @@ func _ready():
 
 	equipment.item_added.connect(_on_item_equiped)
 	equipment.item_removed.connect(_on_item_unequiped)
+	
+	synchronizer.died.connect(_on_died)
 
 	animation_player.play(loop_animation)
 
@@ -54,11 +59,19 @@ func _ready():
 
 		synchronizer.experience_gained.connect(_on_experience_gained)
 		synchronizer.level_gained.connect(_on_level_gained)
+		
+		add_child(death_popup_instance)
+		death_popup_instance.respawn_player.connect(_on_respawn_timer_timeout)
+		death_popup_instance.hide()
+		#died_a = false #- for testing
 
 
 func _physics_process(_delta):
 	if loop_animation == "Move":
 		update_face_direction(velocity.x)
+	#if !died_a: #- for testing
+		#_on_died()
+		#died_a = true
 
 
 func update_face_direction(direction: float):
@@ -189,3 +202,19 @@ func _on_experience_gained(_from: String, _current_exp: int, amount: int):
 
 func _on_level_gained(_current_level: int, _amount: int, _experience_needed: int):
 	update_level()
+	
+	
+func _on_died():
+	#died logic here
+	death_popup_instance.show_popup()
+
+# Timer timeout function
+func _on_respawn_timer_timeout():
+	death_popup_instance.show()
+	respawn_at_nearest_location()
+
+
+func respawn_at_nearest_location():
+	print("respawned")
+	#died_a = false# - for testing, die again
+	#respawn position here

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -25,7 +25,6 @@ extends JPlayerBody2D
 }
 
 var death_popup_instance = load("res://scenes/player/deathpopup/DeathPopup.tscn").instantiate()
-#var died_a #for testing
 
 
 func _ready():
@@ -63,15 +62,11 @@ func _ready():
 		add_child(death_popup_instance)
 		death_popup_instance.respawn_player.connect(_on_respawn_timer_timeout)
 		death_popup_instance.hide()
-		#died_a = false #- for testing
 
 
 func _physics_process(_delta):
 	if loop_animation == "Move":
 		update_face_direction(velocity.x)
-	#if !died_a: #- for testing
-		#_on_died()
-		#died_a = true
 
 
 func update_face_direction(direction: float):
@@ -205,10 +200,8 @@ func _on_level_gained(_current_level: int, _amount: int, _experience_needed: int
 	
 	
 func _on_died():
-	#died logic here
 	death_popup_instance.show_popup()
 
-# Timer timeout function
 func _on_respawn_timer_timeout():
 	death_popup_instance.show()
 	respawn_at_nearest_location()
@@ -216,5 +209,3 @@ func _on_respawn_timer_timeout():
 
 func respawn_at_nearest_location():
 	print("respawned")
-	#died_a = false# - for testing, die again
-	#respawn position here

--- a/scenes/player/Player.tscn
+++ b/scenes/player/Player.tscn
@@ -794,3 +794,8 @@ offset_right = 320.0
 grow_horizontal = 2
 grow_vertical = 0
 theme_override_styles/fill = ExtResource("14_3h4ha")
+
+[node name="DeathPopup" type="Panel" parent="Camera2D/UILayer/GUI"]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0

--- a/scenes/player/deathpopup/DeathPopup.gd
+++ b/scenes/player/deathpopup/DeathPopup.gd
@@ -1,0 +1,27 @@
+extends Panel
+
+signal respawn_player
+var respawn_time: int = 10
+var counter = respawn_time
+
+func _ready():
+	$Timer.timeout.connect(_on_timer_timeout)
+
+func show_popup():
+	self.show()
+	$Timer.set_wait_time(respawn_time)
+	$Timer.start()
+
+func _on_timer_timeout():
+	emit_signal("respawn_player")
+	self.hide()
+	
+func _process(_delta):
+	if !self.visible:
+		return
+		
+	if counter > 0:
+		counter -= 1
+		$CountdownLabel.text = "%d:%02d" % [floor($Timer.time_left / 60), int($Timer.time_left) % 60]
+	else:
+		counter = respawn_time

--- a/scenes/player/deathpopup/DeathPopup.tscn
+++ b/scenes/player/deathpopup/DeathPopup.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=2 format=3 uid="uid://ccq2mcrkefjnb"]
+
+[ext_resource type="Script" path="res://scenes/player/deathpopup/DeathPopup.gd" id="1_augcx"]
+
+[node name="DeathPopup" type="Panel"]
+visibility_layer = 524289
+z_index = 10
+offset_left = -802.0
+offset_top = -639.0
+offset_right = 943.0
+offset_bottom = 615.0
+script = ExtResource("1_augcx")
+
+[node name="TextureRect" type="TextureRect" parent="."]
+layout_mode = 0
+offset_left = -198.0
+offset_top = -143.0
+offset_right = 1919.0
+offset_bottom = 1400.0
+expand_mode = 1
+
+[node name="CountdownLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = -179.0
+offset_top = 660.0
+offset_right = 1809.0
+offset_bottom = 1384.0
+theme_override_font_sizes/font_size = 200
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="DeathTextLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = -187.0
+offset_top = -107.0
+offset_right = 1865.0
+offset_bottom = 666.0
+theme_override_font_sizes/font_size = 200
+text = "YOU DIED"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 10.0
+one_shot = true


### PR DESCRIPTION
Added logic to respawn player on death. All code is in Player.gd, there is also commented code for testing. There is new loaded UI element called death_popup_instance which is popup with text "You died" and 10 seconds countdown timer. UI panel is called DeathPopup and is under GUI on player, it contains 2 labels for text, countdown time and a timer.

issue: https://github.com/jonathaneeckhout/jdungeon/issues/20

UI looks like this
![respawn_ui](https://github.com/jonathaneeckhout/jdungeon/assets/95367472/98636be8-743e-490d-b75a-0d9e980fd524)
