### PR TITLE
bugfix/68+69+72/treeguy-ai-and-player-health

### DIFF
--- a/scenes/enemies/Sheep/Sheep.tscn
+++ b/scenes/enemies/Sheep/Sheep.tscn
@@ -217,7 +217,8 @@ offset_bottom = 25.0
 [node name="AvoidanceRays" parent="." instance=ExtResource("11_nla65")]
 
 [node name="StuckTimer" type="Timer" parent="."]
-wait_time = 1.25
+process_callback = 0
+wait_time = 0.5
 one_shot = true
 
 [node name="Blackboard" type="Node" parent="."]

--- a/scenes/enemies/TreeTrunkGuy/TreeTrunkGuy.tscn
+++ b/scenes/enemies/TreeTrunkGuy/TreeTrunkGuy.tscn
@@ -879,7 +879,8 @@ offset_bottom = -88.0
 [node name="AvoidanceRays" parent="." instance=ExtResource("10_2fx0n")]
 
 [node name="StuckTimer" type="Timer" parent="."]
-wait_time = 1.25
+process_callback = 0
+wait_time = 0.5
 one_shot = true
 
 [node name="AggroRadius" type="Area2D" parent="."]

--- a/scenes/enemies/common/ai/conditionals/is_in_combat/IsInCombat.tscn
+++ b/scenes/enemies/common/ai/conditionals/is_in_combat/IsInCombat.tscn
@@ -6,5 +6,6 @@
 script = ExtResource("1_qltg7")
 
 [node name="ResetTimer" type="Timer" parent="."]
-wait_time = 3.0
+process_callback = 0
+wait_time = 3.5
 one_shot = true

--- a/scenes/enemies/common/ai/sequences/attack_sequence/Attack.gd
+++ b/scenes/enemies/common/ai/sequences/attack_sequence/Attack.gd
@@ -16,8 +16,7 @@ func tick(actor: Node, blackboard: Blackboard):
 		var reset_timer: Timer = blackboard.get_value("reset_timer")
 		reset_timer.start()
 		actor.attack(target)
-		return SUCCESS
-	return FAILURE
+	return SUCCESS
 
 
 func _on_swing_timer_timeout():

--- a/scenes/enemies/common/ai/sequences/attack_sequence/AttackSequence.tscn
+++ b/scenes/enemies/common/ai/sequences/attack_sequence/AttackSequence.tscn
@@ -14,4 +14,5 @@ script = ExtResource("2_r4t7x")
 script = ExtResource("3_67ykl")
 
 [node name="AttackCooldown" type="Timer" parent="Attack"]
+process_callback = 0
 one_shot = true

--- a/scenes/enemies/common/ai/sequences/attack_sequence/ShouldAttack.gd
+++ b/scenes/enemies/common/ai/sequences/attack_sequence/ShouldAttack.gd
@@ -3,6 +3,7 @@ extends ConditionLeaf
 
 func tick(actor: Node, blackboard: Blackboard):
 	var target: JBody2D = blackboard.get_value("aggro_target")
-	if actor.global_position.distance_to(target.global_position) >= actor.stats.attack_range:
+	if actor.global_position.distance_to(target.global_position) <= actor.stats.attack_range:
+		actor.destination = actor.global_position
 		return SUCCESS
 	return FAILURE

--- a/scenes/enemies/common/ai/sequences/leash_sequence/ShouldLeash.gd
+++ b/scenes/enemies/common/ai/sequences/leash_sequence/ShouldLeash.gd
@@ -7,7 +7,6 @@ func tick(actor: Node, blackboard: Blackboard):
 	if blackboard.has_value("leash_position"):
 		if not actor.destination_reached.is_connected(_destination_reached):
 			actor.destination_reached.connect(_destination_reached)
-		J.logger.info("Should leash, erasing leash_position")
 		var leash_position: Vector2 = blackboard.get_value("leash_position")
 		blackboard.set_value("destination_global_position", leash_position)
 		blackboard.erase_value("leash_position")

--- a/scenes/enemies/common/ai/sequences/pursuit_sequence/PursuitSequence.tscn
+++ b/scenes/enemies/common/ai/sequences/pursuit_sequence/PursuitSequence.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=4 format=3 uid="uid://c32syir0x72av"]
 
-[ext_resource type="Script" path="res://addons/beehave/nodes/composites/sequence.gd" id="1_g8y03"]
+[ext_resource type="Script" path="res://addons/beehave/nodes/composites/sequence_reactive.gd" id="1_dl6c3"]
 [ext_resource type="Script" path="res://scenes/enemies/common/ai/sequences/pursuit_sequence/ShouldPursue.gd" id="2_7a5e8"]
 [ext_resource type="PackedScene" uid="uid://dtoop6xo6ukwe" path="res://scenes/enemies/common/ai/actions/move_to/MoveTo.tscn" id="3_b3pvy"]
 
 [node name="PursuitSequence" type="Node"]
-script = ExtResource("1_g8y03")
+script = ExtResource("1_dl6c3")
 
 [node name="ShouldPursue" type="Node" parent="."]
 script = ExtResource("2_7a5e8")

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -26,10 +26,11 @@ extends JPlayerBody2D
 
 
 func _ready():
-	stats.max_hp = 100
+	stats.max_hp = 50
 	synchronizer.loop_animation_changed.connect(_on_loop_animation_changed)
 	synchronizer.attacked.connect(_on_attacked)
 	synchronizer.healed.connect(_on_healed)
+	synchronizer.got_hurt.connect(_on_got_hurt)
 
 	equipment.item_added.connect(_on_item_equiped)
 	equipment.item_removed.connect(_on_item_unequiped)
@@ -92,6 +93,14 @@ func _on_attacked(target: String, _damage: int):
 		return
 
 	update_face_direction(position.direction_to(enemy.position).x)
+
+
+func _on_got_hurt(_from: String, hp: int, max_hp: int, damage: int):
+	$JInterface.update_hp_bar(hp, max_hp)
+	var text = floating_text_scene.instantiate()
+	text.amount = damage
+	text.type = text.TYPES.DAMAGE
+	add_child(text)
 
 
 func _on_healed(_from: String, _hp: int, _max_hp: int, healing: int):

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -35,7 +35,7 @@ respawn_time = null
 
 [node name="TreeTrunkGuy2" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2590, 276)
-respawn = null
+respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy3" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
@@ -95,17 +95,17 @@ respawn_time = null
 
 [node name="TreeTrunkGuy4" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2216, -599)
-respawn = null
+respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy6" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-1807, -1317)
-respawn = null
+respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy7" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2022, -995)
-respawn = null
+respawn = true
 respawn_time = null
 
 [node name="Sheep6" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]


### PR DESCRIPTION
fix(treeGuy,player health): fixed treeguyai and crashes along with adding updates to the player health

TreeGuy AI had some glitches around attacking as well as an unsafe accessor to the "blackboard". I believe I fixed those glitches for both having him attack while in range constantly, as well as the nil crash. Also wired up the Interface to the on_hurt signal from the synchronizer. This should now be showing updated player health. This _should_ fix issues 68, 69, and 72.


Testing Scenario's:
- Get aggro'd by tree guy, walk out of range. He should just reset after enough time passes with no combat action or exceeding his leash range (walking too far away from intial aggro point)
- Get aggro'd and killed by tree guy. Tree guy should reset after killing you. You should see damage numbers on you and see the health bar update. Tree guy should constantly attack you while in range.
  - Existing issue: First death of player still allows him to move and be aggro'd for some reason, unsure what's going on there
- Get Aggro'd by tree guy, attack tree guy until you kill him. He should die and respawn with no issues.
- Get Aggrod, attack a few times, get hit, disengage. Treeguy should just reset, keeps HP, isn't resetting health at the moment.
- Get Aggro'd, get hit a few times, move a little bit away, tree guys should chase and attack more, move a little bit, get attacked more, disengage, tree guy should just reset.

I _think_ those should cover testing well, I tried specifically to target and fix #68 #69 and #72. Let me know if there's anything I need to fix or address further, sorry for the inconvenience. Also changed combat related timers to tie themselves to the physics_process. That *felt* more correct.