### PR TITLE
Add respawn logic and display heals

### DIFF
--- a/scenes/enemies/common/ai/actions/move_to/MoveTo.gd
+++ b/scenes/enemies/common/ai/actions/move_to/MoveTo.gd
@@ -30,8 +30,10 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
 
 func _reset(actor: Node):
-	actor.stuck.disconnect(_stuck)
-	actor.destination_reached.disconnect(_destination_reached)
+	if actor.stuck.is_connected(_stuck):
+		actor.stuck.disconnect(_stuck)
+	if actor.destination_reached.is_connected(_destination_reached):
+		actor.destination_reached.disconnect(_destination_reached)
 	stuck = false
 	destination_reached = false
 

--- a/scenes/items/consumables/healthpotion/HealthPotion.gd
+++ b/scenes/items/consumables/healthpotion/HealthPotion.gd
@@ -6,4 +6,4 @@ func _init():
 
 	item_class = "HealthPotion"
 	consumable = true
-	healing = 3
+	healing = 25

--- a/scenes/loginpanel/LoginPanel.gd
+++ b/scenes/loginpanel/LoginPanel.gd
@@ -7,26 +7,35 @@ signal show_create_account_pressed
 signal back_create_account_pressed
 
 # ConnectContainer
-@onready var server_address_input := $Panel/ConnectContainer/MarginContainer/VBoxContainer/ServerAddressText
-@onready var server_port_input := $Panel/ConnectContainer/MarginContainer2/VBoxContainer/ServerPortText
+@onready
+var server_address_input := $Panel/ConnectContainer/MarginContainer/VBoxContainer/ServerAddressText
+@onready
+var server_port_input := $Panel/ConnectContainer/MarginContainer2/VBoxContainer/ServerPortText
 @onready var connect_button := $Panel/ConnectContainer/MarginContainer3/ConnectButton
 
 #LoginContainer
 @onready var login_container = $Panel/LoginContainer
 @onready var login_input := $Panel/LoginContainer/MarginContainer/VBoxContainer/LoginText
-@onready var login_password_input := $Panel/LoginContainer/MarginContainer2/VBoxContainer/LoginPasswordText
+@onready
+var login_password_input := $Panel/LoginContainer/MarginContainer2/VBoxContainer/LoginPasswordText
 @onready var login_button := $Panel/LoginContainer/MarginContainer3/VBoxContainer/LoginButton
-@onready var goto_create_account_button := $Panel/LoginContainer/MarginContainer3/VBoxContainer/GoToCreateAccountButton
+@onready
+var goto_create_account_button := $Panel/LoginContainer/MarginContainer3/VBoxContainer/GoToCreateAccountButton
 
 #CreateAccountContainer
-@onready var register_login_input := $Panel/CreateAccountContainer/MarginContainer/VBoxContainer/LoginText
-@onready var register_password_input := $Panel/CreateAccountContainer/MarginContainer2/VBoxContainer/PasswordText
-@onready var register_password_confirm_input := $Panel/CreateAccountContainer/MarginContainer2/VBoxContainer/PasswordConfirmText
-@onready var create_account_button := $Panel/CreateAccountContainer/MarginContainer3/VBoxContainer/CreateAccountButton
-@onready var goto_login_button := $Panel/CreateAccountContainer/MarginContainer3/VBoxContainer/BackToLoginButton
+@onready
+var register_login_input := $Panel/CreateAccountContainer/MarginContainer/VBoxContainer/LoginText
+@onready
+var register_password_input := $Panel/CreateAccountContainer/MarginContainer2/VBoxContainer/PasswordText
+@onready
+var register_password_confirm_input := $Panel/CreateAccountContainer/MarginContainer2/VBoxContainer/PasswordConfirmText
+@onready
+var create_account_button := $Panel/CreateAccountContainer/MarginContainer3/VBoxContainer/CreateAccountButton
+@onready
+var goto_login_button := $Panel/CreateAccountContainer/MarginContainer3/VBoxContainer/BackToLoginButton
 
 #AudioStreamers
-@onready var click_audio_stream_player:=$ClickAudioStreamPlayer
+@onready var click_audio_stream_player := $ClickAudioStreamPlayer
 @onready var background_audio_stream_player := $BackgroundAudioStreamPlayer
 
 @onready var _anim_player := $AnimationPlayer
@@ -40,30 +49,35 @@ func _ready():
 	goto_create_account_button.pressed.connect(_on_show_create_account_menu)
 	create_account_button.pressed.connect(_on_create_account_button_pressed)
 	goto_login_button.pressed.connect(_on_back_create_account_button_pressed)
-	
+
 	if not J.is_server():
 		background_audio_stream_player.play()
 		background_audio_stream_player.finished.connect(background_audio_stream_player.play)
-	var buttons : Array = get_tree().get_nodes_in_group("ui_button")
+	var buttons: Array = get_tree().get_nodes_in_group("ui_button")
 	for button in buttons:
 		button.pressed.connect(_on_button_pressed)
 
-func _input(_event):
+
+func _input(event):
 	if login_container.is_visible_in_tree():
-			if Input.is_key_pressed(KEY_ENTER):
-				login_button.emit_signal("pressed")
+		if event.is_action_pressed("ui_accept"):
+			login_button.emit_signal("pressed")
+
 
 func show_connect_container():
 	self.show()
 	_anim_player.play("goto_connect")
 
+
 func show_create_account_container():
 	self.show()
 	_anim_player.play("goto_createaccount")
 
+
 func show_login_container():
 	self.show()
 	_anim_player.play("goto_login")
+
 
 func _on_connect_button_pressed():
 	var server_address = server_address_input.text
@@ -106,11 +120,14 @@ func _on_create_account_button_pressed():
 
 	create_account_pressed.emit(username, password)
 
+
 func _on_back_create_account_button_pressed():
 	back_create_account_pressed.emit()
 
+
 func _on_button_pressed():
 	click_audio_stream_player.play()
+
 
 func stop_login_background_audio():
 	background_audio_stream_player.stop()

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -108,8 +108,12 @@ func _on_got_hurt(_from: String, hp: int, max_hp: int, damage: int):
 	add_child(text)
 
 
-func _on_healed(_from: String, _hp: int, _max_hp: int, healing: int):
-	print("Healed %d" % healing)
+func _on_healed(_from: String, hp: int, max_hp: int, healing: int):
+	$JInterface.update_hp_bar(hp, max_hp)
+	var text = floating_text_scene.instantiate()
+	text.amount = healing
+	text.type = text.TYPES.HEALING
+	add_child(text)
 
 
 func load_equipment_single_sprite(equipment_slot: String):

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -210,3 +210,5 @@ func _on_died():
 
 func _on_respawned():
 	$Camera2D/UILayer/GUI/DeathPopup.hide()
+	# Fetch your new hp
+	stats.get_sync.rpc_id(1, peer_id)

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -216,4 +216,5 @@ func _on_respawned():
 	$Camera2D/UILayer/GUI/DeathPopup.hide()
 	# Fetch your new hp
 	stats.get_sync.rpc_id(1, peer_id)
+	loop_animation = "Idle"
 	animation_player.play(loop_animation)

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -26,7 +26,7 @@ extends JPlayerBody2D
 
 
 func _ready():
-	stats.max_hp = 6
+	stats.max_hp = 50
 	synchronizer.loop_animation_changed.connect(_on_loop_animation_changed)
 	synchronizer.attacked.connect(_on_attacked)
 	synchronizer.healed.connect(_on_healed)

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -24,11 +24,9 @@ extends JPlayerBody2D
 	"LeftHand": $Sprites/LeftHand.texture
 }
 
-var death_popup_instance = load("res://scenes/player/deathpopup/DeathPopup.tscn").instantiate()
-
 
 func _ready():
-	stats.max_hp = 50
+	stats.max_hp = 6
 	synchronizer.loop_animation_changed.connect(_on_loop_animation_changed)
 	synchronizer.attacked.connect(_on_attacked)
 	synchronizer.healed.connect(_on_healed)
@@ -36,8 +34,6 @@ func _ready():
 
 	equipment.item_added.connect(_on_item_equiped)
 	equipment.item_removed.connect(_on_item_unequiped)
-	
-	synchronizer.died.connect(_on_died)
 
 	animation_player.play(loop_animation)
 
@@ -60,10 +56,9 @@ func _ready():
 
 		synchronizer.experience_gained.connect(_on_experience_gained)
 		synchronizer.level_gained.connect(_on_level_gained)
-		
-		add_child(death_popup_instance)
-		death_popup_instance.respawn_player.connect(_on_respawn_timer_timeout)
-		death_popup_instance.hide()
+
+		synchronizer.died.connect(_on_died)
+		synchronizer.respawned.connect(_on_respawned)
 
 
 func _physics_process(_delta):
@@ -207,15 +202,11 @@ func _on_experience_gained(_from: String, _current_exp: int, amount: int):
 
 func _on_level_gained(_current_level: int, _amount: int, _experience_needed: int):
 	update_level()
-	
-	
+
+
 func _on_died():
-	death_popup_instance.show_popup()
-
-func _on_respawn_timer_timeout():
-	death_popup_instance.show()
-	respawn_at_nearest_location()
+	$Camera2D/UILayer/GUI/DeathPopup.show_popup()
 
 
-func respawn_at_nearest_location():
-	print("respawned")
+func _on_respawned():
+	$Camera2D/UILayer/GUI/DeathPopup.hide()

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -42,6 +42,8 @@ func _ready():
 	if J.is_server() or peer_id != multiplayer.get_unique_id():
 		set_process_input(false)
 		$Camera2D.queue_free()
+		# Make sure to load equipment on server side
+		equipment_changed()
 	else:
 		$Camera2D/UILayer/GUI/Inventory.register_signals()
 		$Camera2D/UILayer/GUI/Equipment.register_signals()
@@ -206,9 +208,12 @@ func _on_level_gained(_current_level: int, _amount: int, _experience_needed: int
 
 func _on_died():
 	$Camera2D/UILayer/GUI/DeathPopup.show_popup()
+	animation_player.stop()
+	animation_player.play("Die")
 
 
 func _on_respawned():
 	$Camera2D/UILayer/GUI/DeathPopup.hide()
 	# Fetch your new hp
 	stats.get_sync.rpc_id(1, peer_id)
+	animation_player.play(loop_animation)

--- a/scenes/player/Player.tscn
+++ b/scenes/player/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=3 uid="uid://cycpseafpexil"]
+[gd_scene load_steps=23 format=3 uid="uid://cycpseafpexil"]
 
 [ext_resource type="Script" path="res://scenes/player/Player.gd" id="1_yw2vn"]
 [ext_resource type="Texture2D" uid="uid://fuk2rvw34m4d" path="res://assets/player/base/Basecharacter.png" id="2_dug5c"]
@@ -612,10 +612,254 @@ tracks/11/keys = {
 "update": 0,
 "values": [0.0]
 }
+tracks/12/type = "value"
+tracks/12/imported = false
+tracks/12/enabled = true
+tracks/12/path = NodePath("Skeleton/RemoteBody/RemoteRightArm/RemoteRightHand:position")
+tracks/12/interp = 1
+tracks/12/loop_wrap = true
+tracks/12/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-70, 470)]
+}
+tracks/13/type = "value"
+tracks/13/imported = false
+tracks/13/enabled = true
+tracks/13/path = NodePath("Skeleton/RemoteBody/RemoteRightArm/RemoteRightHand:rotation")
+tracks/13/interp = 1
+tracks/13/loop_wrap = true
+tracks/13/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [-1.5708]
+}
+tracks/14/type = "value"
+tracks/14/imported = false
+tracks/14/enabled = true
+tracks/14/path = NodePath("Skeleton/RemoteBody/RemoteLeftArm/RemoteLeftHand:position")
+tracks/14/interp = 1
+tracks/14/loop_wrap = true
+tracks/14/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-50, 510)]
+}
+tracks/15/type = "value"
+tracks/15/imported = false
+tracks/15/enabled = true
+tracks/15/path = NodePath("Skeleton/RemoteBody/RemoteLeftArm/RemoteLeftHand:rotation")
+tracks/15/interp = 1
+tracks/15/loop_wrap = true
+tracks/15/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [-1.5708]
+}
+
+[sub_resource type="Animation" id="Animation_0iayv"]
+resource_name = "Die"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Skeleton/RemoteBody:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(0, 0), Vector2(10, 343.333), Vector2(10, 476.667)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Skeleton/RemoteBody:rotation")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [0.0, 0.593313, 1.85972, 1.57079]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Skeleton/RemoteBody/RemoteHead:position")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.4, 0.6),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(30, -560), Vector2(30, -560), Vector2(30, -560)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("Skeleton/RemoteBody/RemoteHead:rotation")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.4, 0.6),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [0.0, -0.284084, 0.0]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("Skeleton/RemoteBody/RemoteRightArm:position")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-120, -390)]
+}
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("Skeleton/RemoteBody/RemoteRightArm:rotation")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+tracks/6/type = "value"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("Skeleton/RemoteBody/RemoteRightArm/RemoteRightHand:position")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-70, 470)]
+}
+tracks/7/type = "value"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath("Skeleton/RemoteBody/RemoteRightArm/RemoteRightHand:rotation")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [-1.5708]
+}
+tracks/8/type = "value"
+tracks/8/imported = false
+tracks/8/enabled = true
+tracks/8/path = NodePath("Skeleton/RemoteBody/RemoteLeftArm:position")
+tracks/8/interp = 1
+tracks/8/loop_wrap = true
+tracks/8/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(200, -420)]
+}
+tracks/9/type = "value"
+tracks/9/imported = false
+tracks/9/enabled = true
+tracks/9/path = NodePath("Skeleton/RemoteBody/RemoteLeftArm:rotation")
+tracks/9/interp = 1
+tracks/9/loop_wrap = true
+tracks/9/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+tracks/10/type = "value"
+tracks/10/imported = false
+tracks/10/enabled = true
+tracks/10/path = NodePath("Skeleton/RemoteBody/RemoteLeftArm/RemoteLeftHand:position")
+tracks/10/interp = 1
+tracks/10/loop_wrap = true
+tracks/10/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-50, 510)]
+}
+tracks/11/type = "value"
+tracks/11/imported = false
+tracks/11/enabled = true
+tracks/11/path = NodePath("Skeleton/RemoteBody/RemoteLeftArm/RemoteLeftHand:rotation")
+tracks/11/interp = 1
+tracks/11/loop_wrap = true
+tracks/11/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [-1.5708]
+}
+tracks/12/type = "value"
+tracks/12/imported = false
+tracks/12/enabled = true
+tracks/12/path = NodePath("Skeleton/RemoteBody/RemoteRightLeg:position")
+tracks/12/interp = 1
+tracks/12/loop_wrap = true
+tracks/12/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-80, 49.9999)]
+}
+tracks/13/type = "value"
+tracks/13/imported = false
+tracks/13/enabled = true
+tracks/13/path = NodePath("Skeleton/RemoteBody/RemoteRightLeg:rotation")
+tracks/13/interp = 1
+tracks/13/loop_wrap = true
+tracks/13/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+tracks/14/type = "value"
+tracks/14/imported = false
+tracks/14/enabled = true
+tracks/14/path = NodePath("Skeleton/RemoteBody/RemoteLeftLeg:position")
+tracks/14/interp = 1
+tracks/14/loop_wrap = true
+tracks/14/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(120, 69.9999)]
+}
+tracks/15/type = "value"
+tracks/15/imported = false
+tracks/15/enabled = true
+tracks/15/path = NodePath("Skeleton/RemoteBody/RemoteLeftLeg:rotation")
+tracks/15/interp = 1
+tracks/15/loop_wrap = true
+tracks/15/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_cqja8"]
 _data = {
 "Attack": SubResource("Animation_jutxx"),
+"Die": SubResource("Animation_0iayv"),
 "Idle": SubResource("Animation_00wpy"),
 "Move": SubResource("Animation_25rwv"),
 "RESET": SubResource("Animation_tvg6c")
@@ -636,49 +880,53 @@ texture = ExtResource("2_dug5c")
 metadata/_edit_lock_ = true
 
 [node name="RightArm" type="Sprite2D" parent="Sprites"]
-position = Vector2(150, 0)
+position = Vector2(670, 746.666)
+rotation = 1.57079
 texture = ExtResource("4_gw0jc")
 offset = Vector2(131, 228)
 metadata/_edit_lock_ = true
 
 [node name="RightHand" type="Sprite2D" parent="Sprites"]
-position = Vector2(80, 470)
-rotation = -1.5708
+position = Vector2(200, 676.667)
 offset = Vector2(0.00012207, 800)
 metadata/_edit_lock_ = true
 
 [node name="RightLeg" type="Sprite2D" parent="Sprites"]
-position = Vector2(190, 440)
+position = Vector2(230, 786.667)
+rotation = 1.57079
 texture = ExtResource("7_jpcwx")
 offset = Vector2(91, -212)
 metadata/_edit_lock_ = true
 
 [node name="LeftLeg" type="Sprite2D" parent="Sprites"]
-position = Vector2(390, 460)
+position = Vector2(210, 986.667)
+rotation = 1.57079
 texture = ExtResource("6_ph7fa")
 offset = Vector2(-109, -232)
 metadata/_edit_lock_ = true
 
 [node name="Body" type="Sprite2D" parent="Sprites"]
-position = Vector2(270, 390)
+position = Vector2(280, 866.667)
+rotation = 1.57079
 texture = ExtResource("8_n1x5o")
 offset = Vector2(11, -162)
 metadata/_edit_lock_ = true
 
 [node name="Head" type="Sprite2D" parent="Sprites"]
-position = Vector2(300, -170)
+position = Vector2(840, 896.665)
+rotation = 1.57079
 texture = ExtResource("5_dr4ej")
 offset = Vector2(-19, 398)
 metadata/_edit_lock_ = true
 
 [node name="LeftHand" type="Sprite2D" parent="Sprites"]
-position = Vector2(420, 480)
-rotation = -1.5708
+position = Vector2(190, 1016.67)
 offset = Vector2(0.00012207, 800)
 metadata/_edit_lock_ = true
 
 [node name="LeftArm" type="Sprite2D" parent="Sprites"]
-position = Vector2(470, -30)
+position = Vector2(700, 1066.67)
+rotation = 1.57079
 texture = ExtResource("3_dw8ng")
 offset = Vector2(-189, 248)
 metadata/_edit_lock_ = true

--- a/scenes/player/Player.tscn
+++ b/scenes/player/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://cycpseafpexil"]
+[gd_scene load_steps=22 format=3 uid="uid://cycpseafpexil"]
 
 [ext_resource type="Script" path="res://scenes/player/Player.gd" id="1_yw2vn"]
 [ext_resource type="Texture2D" uid="uid://fuk2rvw34m4d" path="res://assets/player/base/Basecharacter.png" id="2_dug5c"]
@@ -14,6 +14,7 @@
 [ext_resource type="PackedScene" uid="uid://dssmk0m8xsvxf" path="res://scenes/ui/game_menu/game_menu.tscn" id="13_musf7"]
 [ext_resource type="PackedScene" uid="uid://bqsdy2usb2e6d" path="res://scenes/player/equipment/Equipment.tscn" id="14_2fdu8"]
 [ext_resource type="StyleBox" uid="uid://pbfuprosr3en" path="res://assets/themes/ProgressBars.tres" id="14_3h4ha"]
+[ext_resource type="PackedScene" uid="uid://ccq2mcrkefjnb" path="res://scenes/player/deathpopup/DeathPopup.tscn" id="15_ho0h1"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_lk3fd"]
 radius = 32.0
@@ -795,7 +796,6 @@ grow_horizontal = 2
 grow_vertical = 0
 theme_override_styles/fill = ExtResource("14_3h4ha")
 
-[node name="DeathPopup" type="Panel" parent="Camera2D/UILayer/GUI"]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
+[node name="DeathPopup" parent="Camera2D/UILayer/GUI" instance=ExtResource("15_ho0h1")]
+visible = false
+layout_mode = 1

--- a/scenes/player/Player.tscn
+++ b/scenes/player/Player.tscn
@@ -880,53 +880,49 @@ texture = ExtResource("2_dug5c")
 metadata/_edit_lock_ = true
 
 [node name="RightArm" type="Sprite2D" parent="Sprites"]
-position = Vector2(670, 746.666)
-rotation = 1.57079
+position = Vector2(150, 0)
 texture = ExtResource("4_gw0jc")
 offset = Vector2(131, 228)
 metadata/_edit_lock_ = true
 
 [node name="RightHand" type="Sprite2D" parent="Sprites"]
-position = Vector2(200, 676.667)
+position = Vector2(80, 470)
+rotation = -1.5708
 offset = Vector2(0.00012207, 800)
 metadata/_edit_lock_ = true
 
 [node name="RightLeg" type="Sprite2D" parent="Sprites"]
-position = Vector2(230, 786.667)
-rotation = 1.57079
+position = Vector2(190, 440)
 texture = ExtResource("7_jpcwx")
 offset = Vector2(91, -212)
 metadata/_edit_lock_ = true
 
 [node name="LeftLeg" type="Sprite2D" parent="Sprites"]
-position = Vector2(210, 986.667)
-rotation = 1.57079
+position = Vector2(390, 460)
 texture = ExtResource("6_ph7fa")
 offset = Vector2(-109, -232)
 metadata/_edit_lock_ = true
 
 [node name="Body" type="Sprite2D" parent="Sprites"]
-position = Vector2(280, 866.667)
-rotation = 1.57079
+position = Vector2(270, 390)
 texture = ExtResource("8_n1x5o")
 offset = Vector2(11, -162)
 metadata/_edit_lock_ = true
 
 [node name="Head" type="Sprite2D" parent="Sprites"]
-position = Vector2(840, 896.665)
-rotation = 1.57079
+position = Vector2(300, -170)
 texture = ExtResource("5_dr4ej")
 offset = Vector2(-19, 398)
 metadata/_edit_lock_ = true
 
 [node name="LeftHand" type="Sprite2D" parent="Sprites"]
-position = Vector2(190, 1016.67)
+position = Vector2(420, 480)
+rotation = -1.5708
 offset = Vector2(0.00012207, 800)
 metadata/_edit_lock_ = true
 
 [node name="LeftArm" type="Sprite2D" parent="Sprites"]
-position = Vector2(700, 1066.67)
-rotation = 1.57079
+position = Vector2(470, -30)
 texture = ExtResource("3_dw8ng")
 offset = Vector2(-189, 248)
 metadata/_edit_lock_ = true

--- a/scenes/player/deathpopup/DeathPopup.gd
+++ b/scenes/player/deathpopup/DeathPopup.gd
@@ -1,27 +1,38 @@
-extends Panel
+extends Control
 
 signal respawn_player
-var respawn_time: int = 10
+var respawn_time: float = J.PLAYER_RESPAWN_TIME
 var counter = respawn_time
+var timer: Timer
+@onready var count_down_label: Label = $Panel/CountdownLabel
+
 
 func _ready():
-	$Timer.timeout.connect(_on_timer_timeout)
+	timer = Timer.new()
+	timer.name = "Timer"
+	timer.autostart = false
+	timer.timeout.connect(_on_timer_timeout)
+	add_child(timer)
+
 
 func show_popup():
 	self.show()
-	$Timer.set_wait_time(respawn_time)
-	$Timer.start()
+	timer.start(respawn_time)
+
 
 func _on_timer_timeout():
 	emit_signal("respawn_player")
 	self.hide()
-	
+
+
 func _process(_delta):
 	if !self.visible:
 		return
-		
+
 	if counter > 0:
 		counter -= 1
-		$CountdownLabel.text = "%d:%02d" % [floor($Timer.time_left / 60), int($Timer.time_left) % 60]
+		count_down_label.text = (
+			"%d:%02d" % [floor(timer.time_left / 60), int(timer.time_left) % 60]
+		)
 	else:
 		counter = respawn_time

--- a/scenes/player/deathpopup/DeathPopup.gd
+++ b/scenes/player/deathpopup/DeathPopup.gd
@@ -1,9 +1,10 @@
 extends Control
 
-signal respawn_player
 var respawn_time: float = J.PLAYER_RESPAWN_TIME
-var counter = respawn_time
+
 var timer: Timer
+var countdown_timer: Timer
+
 @onready var count_down_label: Label = $Panel/CountdownLabel
 
 
@@ -11,28 +12,33 @@ func _ready():
 	timer = Timer.new()
 	timer.name = "Timer"
 	timer.autostart = false
+	timer.one_shot = true
 	timer.timeout.connect(_on_timer_timeout)
 	add_child(timer)
+
+	countdown_timer = Timer.new()
+	countdown_timer.name = "CountDownTimer"
+	countdown_timer.autostart = false
+	countdown_timer.wait_time = 1.0
+	countdown_timer.timeout.connect(_on_countdown_timer_timeout)
+	add_child(countdown_timer)
 
 
 func show_popup():
 	self.show()
 	timer.start(respawn_time)
+	countdown_timer.start(0.1)
+	update_counter()
+
+
+func update_counter():
+	count_down_label.text = ("%d:%02d" % [floor(timer.time_left / 60), int(timer.time_left) % 60])
 
 
 func _on_timer_timeout():
-	emit_signal("respawn_player")
+	countdown_timer.stop()
 	self.hide()
 
 
-func _process(_delta):
-	if !self.visible:
-		return
-
-	if counter > 0:
-		counter -= 1
-		count_down_label.text = (
-			"%d:%02d" % [floor(timer.time_left / 60), int(timer.time_left) % 60]
-		)
-	else:
-		counter = respawn_time
+func _on_countdown_timer_timeout():
+	update_counter()

--- a/scenes/player/deathpopup/DeathPopup.tscn
+++ b/scenes/player/deathpopup/DeathPopup.tscn
@@ -2,44 +2,68 @@
 
 [ext_resource type="Script" path="res://scenes/player/deathpopup/DeathPopup.gd" id="1_augcx"]
 
-[node name="DeathPopup" type="Panel"]
+[node name="DeathPopup" type="Control"]
 visibility_layer = 524289
-z_index = 10
-offset_left = -802.0
-offset_top = -639.0
-offset_right = 943.0
-offset_bottom = 615.0
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 script = ExtResource("1_augcx")
 
-[node name="TextureRect" type="TextureRect" parent="."]
-layout_mode = 0
-offset_left = -198.0
-offset_top = -143.0
-offset_right = 1919.0
-offset_bottom = 1400.0
-expand_mode = 1
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="CountdownLabel" type="Label" parent="."]
-layout_mode = 0
-offset_left = -179.0
-offset_top = 660.0
-offset_right = 1809.0
-offset_bottom = 1384.0
+[node name="DeathTextLabel" type="Label" parent="Panel"]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -471.0
+offset_right = 471.0
+offset_bottom = 276.0
+grow_horizontal = 2
 theme_override_font_sizes/font_size = 200
+text = "You died"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="DeathTextLabel" type="Label" parent="."]
-layout_mode = 0
-offset_left = -187.0
-offset_top = -107.0
-offset_right = 1865.0
-offset_bottom = 666.0
+[node name="RespawnTextLabel" type="Label" parent="Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -727.5
+offset_top = -138.0
+offset_right = 727.5
+offset_bottom = 138.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_font_sizes/font_size = 200
-text = "YOU DIED"
+text = "Respawning in:"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Timer" type="Timer" parent="."]
-wait_time = 10.0
-one_shot = true
+[node name="CountdownLabel" type="Label" parent="Panel"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -0.5
+offset_top = -273.0
+offset_right = 0.5
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_font_sizes/font_size = 200
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/player/deathpopup/DeathPopup.tscn
+++ b/scenes/player/deathpopup/DeathPopup.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://ccq2mcrkefjnb"]
+[gd_scene load_steps=3 format=3 uid="uid://ccq2mcrkefjnb"]
 
 [ext_resource type="Script" path="res://scenes/player/deathpopup/DeathPopup.gd" id="1_augcx"]
+[ext_resource type="Theme" uid="uid://dreboohjjcn2f" path="res://assets/themes/LoginPanelTheme.tres" id="2_htxd2"]
 
 [node name="DeathPopup" type="Control"]
 visibility_layer = 524289
@@ -14,9 +15,15 @@ script = ExtResource("1_augcx")
 
 [node name="Panel" type="Panel" parent="."]
 layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -500.0
+offset_top = -340.0
+offset_right = 500.0
+offset_bottom = 340.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -29,6 +36,7 @@ offset_left = -471.0
 offset_right = 471.0
 offset_bottom = 276.0
 grow_horizontal = 2
+theme = ExtResource("2_htxd2")
 theme_override_font_sizes/font_size = 200
 text = "You died"
 horizontal_alignment = 1
@@ -47,6 +55,7 @@ offset_right = 727.5
 offset_bottom = 138.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("2_htxd2")
 theme_override_font_sizes/font_size = 200
 text = "Respawning in:"
 horizontal_alignment = 1
@@ -64,6 +73,7 @@ offset_top = -273.0
 offset_right = 0.5
 grow_horizontal = 2
 grow_vertical = 0
+theme = ExtResource("2_htxd2")
 theme_override_font_sizes/font_size = 200
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/scenes/player/playersrepsawnlocation/PlayerRespawnLocation.tscn
+++ b/scenes/player/playersrepsawnlocation/PlayerRespawnLocation.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://cflqdnl6156j8"]
+
+[node name="PlayerRespawnLocation" type="Node2D"]

--- a/scenes/world/World.gd
+++ b/scenes/world/World.gd
@@ -9,6 +9,7 @@ func _ready():
 	map_to_sync = $Entities/Map
 	enemies_to_sync = $Entities/Enemies
 	npcs_to_sync = $Entities/NPCs
+	player_respawn_locations = $PlayerRespawnLocations
 
 	super()
 

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -31,82 +31,82 @@ offset_bottom = 400.0
 
 [node name="TreeTrunkGuy" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2164, 1328)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy2" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2590, 276)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy3" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-3139, 1193)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy8" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-3584, 1706)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy9" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-4239, 1075)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy10" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-4691, 1501)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy11" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-5313, 414)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy13" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-5678, -701)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy14" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-5029, -1043)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy15" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-4816, -611)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy16" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-3994, -1151)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy17" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-3149, -1262)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy12" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-5405, 1397)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy4" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2216, -599)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy6" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-1807, -1317)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="TreeTrunkGuy7" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2022, -995)
-respawn = true
+should_respawn = true
 respawn_time = null
 
 [node name="Sheep6" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://beiq65may6bdw"]
+[gd_scene load_steps=13 format=3 uid="uid://beiq65may6bdw"]
 
 [ext_resource type="Script" path="res://scenes/world/World.gd" id="1_3w1ia"]
 [ext_resource type="PackedScene" uid="uid://bdgegw7cy4d1r" path="res://scenes/loginpanel/LoginPanel.tscn" id="2_fjr74"]
@@ -11,6 +11,7 @@
 [ext_resource type="PackedScene" uid="uid://8qc41ibiwbw" path="res://scenes/terrain/nature/trees/pinetreelarge/PineTreeLarge.tscn" id="8_jrm0a"]
 [ext_resource type="PackedScene" uid="uid://koikh2ns5rr8" path="res://scenes/terrain/nature/trees/pinetreemedium/PineTreeMedium.tscn" id="9_oy0uv"]
 [ext_resource type="PackedScene" uid="uid://dh1m2cphq5kev" path="res://scenes/terrain/nature/trees/pinetreeshort/PineTreeShort.tscn" id="10_1j8e4"]
+[ext_resource type="PackedScene" uid="uid://cflqdnl6156j8" path="res://scenes/player/playersrepsawnlocation/PlayerRespawnLocation.tscn" id="12_7jhmb"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1_3w1ia")
@@ -219,6 +220,11 @@ position = Vector2(503, -741)
 
 [node name="PineTreeShort4" parent="Entities/Map/Nature" instance=ExtResource("10_1j8e4")]
 position = Vector2(72, -1061)
+
+[node name="PlayerRespawnLocations" type="Node2D" parent="."]
+
+[node name="PlayerRespawnLocation" parent="PlayerRespawnLocations" instance=ExtResource("12_7jhmb")]
+position = Vector2(-32, -48)
 
 [node name="Camera2D" type="Camera2D" parent="."]
 anchor_mode = 0

--- a/scripts/classes/JBody2D.gd
+++ b/scripts/classes/JBody2D.gd
@@ -51,6 +51,8 @@ func hurt(from: CharacterBody2D, damage: int):
 		if stats.experience_given > 0:
 			from.stats.add_experience(name, stats.experience_given)
 
+	# Can't die twice
+	if not is_dead:
 		die()
 
 
@@ -80,12 +82,8 @@ func die():
 func respawn(location: Vector2):
 	position = location
 	is_dead = false
-	collision_layer -= J.PHYSICS_LAYER_WORLD
+	collision_layer += J.PHYSICS_LAYER_WORLD
 	stats.reset_hp()
-
-	velocity = Vector2.ZERO
-	loop_animation = "Idle"
-	synchronizer.sync_loop_animation(loop_animation, velocity)
 
 	respawned.emit()
 

--- a/scripts/classes/JBody2D.gd
+++ b/scripts/classes/JBody2D.gd
@@ -51,9 +51,9 @@ func hurt(from: CharacterBody2D, damage: int):
 		if stats.experience_given > 0:
 			from.stats.add_experience(name, stats.experience_given)
 
-	# Can't die twice
-	if not is_dead:
-		die()
+		# Can't die twice
+		if not is_dead:
+			die()
 
 
 func heal(from: CharacterBody2D, healing: int):

--- a/scripts/classes/JBody2D.gd
+++ b/scripts/classes/JBody2D.gd
@@ -3,6 +3,7 @@ extends CharacterBody2D
 class_name JBody2D
 
 signal died
+signal respawned
 
 var entity_type: J.ENTITY_TYPE = J.ENTITY_TYPE.ENEMY
 var synchronizer: JSynchronizer
@@ -66,6 +67,7 @@ func send_new_loop_animation(animation: String):
 
 
 func die():
+	is_dead = true
 	collision_layer -= J.PHYSICS_LAYER_WORLD
 
 	died.emit()
@@ -73,6 +75,21 @@ func die():
 	synchronizer.sync_die()
 
 	drop_loot()
+
+
+func respawn(location: Vector2):
+	position = location
+	is_dead = false
+	collision_layer -= J.PHYSICS_LAYER_WORLD
+	stats.reset_hp()
+
+	velocity = Vector2.ZERO
+	loop_animation = "Idle"
+	synchronizer.sync_loop_animation(loop_animation, velocity)
+
+	respawned.emit()
+
+	synchronizer.sync_respawn()
 
 
 func drop_loot():

--- a/scripts/classes/JEnemyBody2D.gd
+++ b/scripts/classes/JEnemyBody2D.gd
@@ -6,7 +6,7 @@ const DESPAWN_TIME = 10.0
 
 var enemy_class: String = ""
 
-@export var respawn: bool = false
+@export var should_respawn: bool = false
 @export var respawn_time: float = 10.0
 
 @onready var spawn_position: Vector2 = position
@@ -41,7 +41,7 @@ func die():
 
 
 func _on_despawn_timer_timeout():
-	if respawn:
+	if should_respawn:
 		J.world.queue_enemy_respawn(enemy_class, spawn_position, respawn_time)
 
 	queue_free()

--- a/scripts/classes/JEnemyRespawn.gd
+++ b/scripts/classes/JEnemyRespawn.gd
@@ -21,7 +21,7 @@ func _on_respawn_timer_timeout():
 	var enemy: JEnemyBody2D = J.enemy_scenes[enemy_class].instantiate()
 	enemy.name = str(enemy.get_instance_id())
 	enemy.position = respawn_position
-	enemy.respawn = true
+	enemy.should_respawn = true
 	enemy.respawn_time = respawn_time
 
 	J.world.enemies.add_child(enemy)

--- a/scripts/classes/JPlayerBody2D.gd
+++ b/scripts/classes/JPlayerBody2D.gd
@@ -73,7 +73,15 @@ func _init():
 func die():
 	super()
 
+	collision_layer -= J.PHYSICS_LAYER_PLAYERS
+
 	respawn_timer.start(J.PLAYER_RESPAWN_TIME)
+
+
+func respawn(location: Vector2):
+	super(location)
+
+	collision_layer += J.PHYSICS_LAYER_PLAYERS
 
 
 func store_data():

--- a/scripts/classes/JPlayerBody2D.gd
+++ b/scripts/classes/JPlayerBody2D.gd
@@ -58,6 +58,7 @@ func _init():
 		respawn_timer = Timer.new()
 		respawn_timer.name = "RespawnTimer"
 		respawn_timer.autostart = false
+		respawn_timer.one_shot = true
 		respawn_timer.wait_time = J.PLAYER_RESPAWN_TIME
 		respawn_timer.timeout.connect(_on_respawn_timer_timeout)
 		add_child(respawn_timer)

--- a/scripts/classes/JPlayerBody2D.gd
+++ b/scripts/classes/JPlayerBody2D.gd
@@ -2,8 +2,6 @@ extends JBody2D
 
 class_name JPlayerBody2D
 
-signal respawned
-
 var peer_id: int = 1
 var username: String = ""
 
@@ -97,20 +95,4 @@ func _on_persistency_timer_timeout():
 
 func _on_respawn_timer_timeout():
 	var respawn_location: Vector2 = J.world.find_player_respawn_location(self.position)
-
-	# Set the player to the respawn location
-	position = respawn_location
-
-	#Let's bring the player back to life
-	stats.reset_hp()
-
-	velocity = Vector2.ZERO
-	loop_animation = "Idle"
-	synchronizer.sync_loop_animation(loop_animation, velocity)
-
-	# Let the player take part of the world again
-	collision_layer += J.PHYSICS_LAYER_WORLD
-
-	respawned.emit()
-
-	synchronizer.sync_respawn()
+	respawn(respawn_location)

--- a/scripts/classes/JPlayerSynchronizer.gd
+++ b/scripts/classes/JPlayerSynchronizer.gd
@@ -55,6 +55,7 @@ func _ready():
 
 
 func _on_body_network_view_area_body_entered(body: JBody2D):
+	# Don't handle the player as we hardcoded it to be added to the watchers
 	if body == player:
 		return
 
@@ -75,6 +76,10 @@ func _on_body_network_view_area_body_entered(body: JBody2D):
 
 
 func _on_body_network_view_area_body_exited(body: JBody2D):
+	# Make sure that the player is never removed from the watchers
+	if body == player:
+		return
+
 	if bodies_in_view.has(body):
 		if player.peer_id in multiplayer.get_peers():
 			match body.entity_type:

--- a/scripts/classes/JSynchronizer.gd
+++ b/scripts/classes/JSynchronizer.gd
@@ -7,10 +7,11 @@ signal got_hurt(from: String, hp: int, max_hp: int, damage: int)
 signal healed(from: String, hp: int, max_hp: int, healing: int)
 signal loop_animation_changed(animation: String, direction: Vector2)
 signal died
+signal respawned
 signal experience_gained(from: String, current_exp: int, amount: int)
 signal level_gained(current_level: int, amount: int, experience_needed: int)
 
-enum SYNC_TYPES { ATTACK, HURT, HEAL, LOOP_ANIMATION, DIE, EXPERIENCE, LEVEL }
+enum SYNC_TYPES { ATTACK, HURT, HEAL, LOOP_ANIMATION, DIE, RESPAWN, EXPERIENCE, LEVEL }
 
 const INTERPOLATION_OFFSET = 0.1
 const INTERPOLATION_INDEX = 2
@@ -119,6 +120,8 @@ func check_server_network_buffer():
 					loop_animation_changed.emit(entry["animation"], entry["direction"])
 				SYNC_TYPES.DIE:
 					died.emit()
+				SYNC_TYPES.RESPAWN:
+					respawned.emit()
 				SYNC_TYPES.EXPERIENCE:
 					to_be_synced.stats.experience = entry["current_exp"]
 
@@ -176,6 +179,15 @@ func sync_die():
 		die.rpc_id(watcher.peer_id, timestamp)
 
 	died.emit()
+
+
+func sync_respawn():
+	var timestamp = Time.get_unix_time_from_system()
+
+	for watcher in watchers:
+		respawn.rpc_id(watcher.peer_id, timestamp)
+
+	respawned.emit()
 
 
 func sync_experience(from: String, current_exp: int, amount: int):
@@ -255,6 +267,10 @@ func loop_animation(timestamp: float, animation: String, direction: Vector2):
 
 @rpc("call_remote", "authority", "reliable") func die(timestamp: float):
 	server_network_buffer.append({"type": SYNC_TYPES.DIE, "timestamp": timestamp})
+
+
+@rpc("call_remote", "authority", "reliable") func respawn(timestamp: float):
+	server_network_buffer.append({"type": SYNC_TYPES.RESPAWN, "timestamp": timestamp})
 
 
 @rpc("call_remote", "authority", "reliable")

--- a/scripts/classes/JSynchronizer.gd
+++ b/scripts/classes/JSynchronizer.gd
@@ -270,6 +270,10 @@ func loop_animation(timestamp: float, animation: String, direction: Vector2):
 
 
 @rpc("call_remote", "authority", "reliable") func respawn(timestamp: float):
+	# Clear the buffers to reset the inter and extrapolation
+	server_syncs_buffer = []
+	server_network_buffer = []
+
 	server_network_buffer.append({"type": SYNC_TYPES.RESPAWN, "timestamp": timestamp})
 
 

--- a/scripts/classes/JWorld.gd
+++ b/scripts/classes/JWorld.gd
@@ -5,6 +5,7 @@ class_name JWorld
 @export var map_to_sync: Node2D
 @export var enemies_to_sync: Node2D
 @export var npcs_to_sync: Node2D
+@export var player_respawn_locations: Node2D
 
 var players: Node2D
 var enemies: Node2D
@@ -108,6 +109,25 @@ func get_player_by_peer_id(peer_id: int) -> JPlayerBody2D:
 			return player
 
 	return null
+
+
+func find_player_respawn_location(player_position: Vector2) -> Vector2:
+	var spots = player_respawn_locations.get_children()
+
+	if len(spots) == 0:
+		J.logger.warn("No player respawn spots found, returning current player's position")
+		return player_position
+
+	var closest = spots[0].position
+	var closest_distance = closest.distance_to(player_position)
+
+	for spot in spots:
+		var distance = spot.position.distance_to(player_position)
+		if distance < closest_distance:
+			closest = spot.position
+			closest_distance = distance
+
+	return closest
 
 
 func _on_player_logged_in(id: int, username: String):

--- a/scripts/classes/JWorld.gd
+++ b/scripts/classes/JWorld.gd
@@ -153,6 +153,11 @@ func _on_peer_disconnected(id):
 	if id in players_by_id:
 		var player = players_by_id[id]
 
+		# If the player is dead, we will respawn him first before storing the player's data
+		if player.is_dead:
+			player.position = find_player_respawn_location(player.position)
+			player.stats.reset_hp()
+
 		player.store_data()
 
 		J.logger.info("Removing player=[%s]" % player.name)

--- a/scripts/classes/behaviors/JPlayerBehavior.gd
+++ b/scripts/classes/behaviors/JPlayerBehavior.gd
@@ -106,6 +106,7 @@ func _physics_process(delta: float):
 	if J.is_server():
 		behavior(delta)
 
+	if not player.is_dead:
 		player.move_and_slide()
 
 
@@ -115,6 +116,7 @@ func behavior(_delta: float):
 		moving = false
 		interacting = false
 		interact_target = null
+		player.send_new_loop_animation("Idle")
 	elif moving:
 		if player.position.distance_to(move_target) > J.ARRIVAL_DISTANCE:
 			player.velocity = (

--- a/scripts/classes/behaviors/JPlayerBehavior.gd
+++ b/scripts/classes/behaviors/JPlayerBehavior.gd
@@ -110,7 +110,12 @@ func _physics_process(delta: float):
 
 
 func behavior(_delta: float):
-	if moving:
+	if player.is_dead:
+		player.velocity = Vector2.ZERO
+		moving = false
+		interacting = false
+		interact_target = null
+	elif moving:
 		if player.position.distance_to(move_target) > J.ARRIVAL_DISTANCE:
 			player.velocity = (
 				player.position.direction_to(move_target) * player_stats.movement_speed

--- a/scripts/classes/behaviors/JPlayerBehavior.gd
+++ b/scripts/classes/behaviors/JPlayerBehavior.gd
@@ -116,7 +116,6 @@ func behavior(_delta: float):
 		moving = false
 		interacting = false
 		interact_target = null
-		player.send_new_loop_animation("Idle")
 	elif moving:
 		if player.position.distance_to(move_target) > J.ARRIVAL_DISTANCE:
 			player.velocity = (

--- a/scripts/singletons/jdungeon.gd
+++ b/scripts/singletons/jdungeon.gd
@@ -13,6 +13,7 @@ const ARRIVAL_DISTANCE = 8
 const DROP_RANGE = 64
 
 const PERSISTENCY_INTERVAL = 60.0
+const PLAYER_RESPAWN_TIME = 10.0
 
 const USERS_FILEPATH = "data/users.json"
 


### PR DESCRIPTION
New:
- #20 
- Add a player's respawn location
- When dead, the player will respawn to the closest respawn location

Fix:
- #44 
- No visual update when consuming a healthpotion

How to test:
Test 1:
- Let an enemy (treetrunkguy) kill you
- The Die animation should play
- You died panel should pop up with a counter that decreases from 10
- Enemies should not hit you anymore
- Wait for the timer to reach 0
- While waiting you should not be able to do anything
- when the timer reached 0 you should respawn at a respawn spot (check world) and the you died panel should disappear.  

Test 2:
- Die from an enemy
- During the respawn time close the client or disconnect
- Log back in, you should have been respawned with full hp

Test 3:
- Use a healthpotion while your hp is lower, it should display +25 and your hp should be increased.

Test 4:
- When you login, you can hold enter and your player will only be spawned once

Disclaimers:
If a player dies, he/she can disconnect and connect again to get a quicker respawn. For me it's not really an issue as most of the times it takes longer than 10sec to connect again.