### PR TITLE
fix wrong error and hard coded json backend filepath

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ SERVER_KEY=test/localhost.key
 SERVER_MAX_PEERS=128
 SERVER_DATABASE_BACKEND=json
 # Only required if backend is "json"
-SERVER_JSON_BACKEND_FILE="data/users.json"
+SERVER_JSON_BACKEND_FILE="res://data/users.json"
 
 # Only required if backend is "postgres"
 # POSTGRES_ADDRESS=127.0.0.1

--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,15 @@ SERVER_CRT=test/localhost.crt
 SERVER_KEY=test/localhost.key
 SERVER_MAX_PEERS=128
 SERVER_DATABASE_BACKEND=json
+# Only required if backend is "json"
+SERVER_JSON_BACKEND_FILE="data/users.json"
+
+# Only required if backend is "postgres"
+# POSTGRES_ADDRESS=127.0.0.1
+# POSTGRES_PORT=5432
+# POSTGRES_USER=testuser
+# POSTGRES_PASSWORD=testpassword
+# POSTGRES_DB=jdungeon
+
 DEBUG=true
 AUDIO_MUTE=false
-
-POSTGRES_ADDRESS=127.0.0.1
-POSTGRES_PORT=5432
-POSTGRES_USER=testuser
-POSTGRES_PASSWORD=testpassword
-POSTGRES_DB=jdungeon

--- a/scripts/global.gd
+++ b/scripts/global.gd
@@ -6,6 +6,7 @@ var env_server_max_peers: int = 0
 var env_server_crt: String = ""
 var env_server_key: String = ""
 var env_server_database_backend: String = ""
+var env_server_json_backend_file: String = ""
 var env_debug: bool = false
 var env_audio_mute: bool = false
 
@@ -46,27 +47,34 @@ func load_server_env_variables() -> bool:
 	if env_server_database_backend == "":
 		return false
 
-	env_postgres_address = J.env.get_value("POSTGRES_ADDRESS")
-	if env_postgres_address == "":
-		return false
+	match env_server_database_backend:
+		"json":
+			env_server_json_backend_file = J.env.get_value("SERVER_JSON_BACKEND_FILE")
+			if env_server_json_backend_file == "":
+				return false
+		"postgres":
+			env_postgres_address = J.env.get_value("POSTGRES_ADDRESS")
+			if env_postgres_address == "":
+				return false
 
-	var env_postgres_port_str = J.env.get_value("POSTGRES_PORT")
-	if env_postgres_port_str == "":
-		return false
+			var env_postgres_port_str = J.env.get_value("POSTGRES_PORT")
+			if env_postgres_port_str == "":
+				return false
 
-	env_postgres_port = int(env_postgres_port_str)
+			env_postgres_port = int(env_postgres_port_str)
 
-	env_postgres_user = J.env.get_value("POSTGRES_USER")
-	if env_postgres_user == "":
-		return false
+			env_postgres_user = J.env.get_value("POSTGRES_USER")
+			if env_postgres_user == "":
+				return false
 
-	env_postgress_password = J.env.get_value("POSTGRES_PASSWORD")
-	if env_postgress_password == "":
-		return false
+			env_postgress_password = J.env.get_value("POSTGRES_PASSWORD")
+			if env_postgress_password == "":
+				return false
 
-	env_postgress_db = J.env.get_value("POSTGRES_DB")
-	if env_postgress_db == "":
-		return false
+			env_postgress_db = J.env.get_value("POSTGRES_DB")
+			if env_postgress_db == "":
+				return false
+
 	return true
 
 

--- a/scripts/network/database/backends/JJSONDatabaseBackend.gd
+++ b/scripts/network/database/backends/JJSONDatabaseBackend.gd
@@ -5,7 +5,7 @@ class_name JJSONDatabaseBackend
 
 # Upercase function name to match csharp style
 func Init() -> bool:
-	return create_file_if_not_exists(J.USERS_FILEPATH, {})
+	return create_file_if_not_exists(J.global.env_server_json_backend_file, {})
 
 
 func create_file_if_not_exists(path: String, json_data: Dictionary) -> bool:
@@ -19,7 +19,7 @@ func create_file_if_not_exists(path: String, json_data: Dictionary) -> bool:
 func write_json_to_file(path: String, json_data: Dictionary) -> bool:
 	var file = FileAccess.open(path, FileAccess.WRITE)
 	if file == null:
-		J.logger.err("Could not open file=[%s] to write" % path)
+		J.logger.error("Could not open file=[%s] to write" % path)
 		return false
 
 	var string_data = JSON.stringify(json_data, "    ")
@@ -43,11 +43,11 @@ func read_json_from_file(path: String) -> Variant:
 
 
 func CreateAccount(username: String, password: String) -> Dictionary:
-	var users_json: Variant = read_json_from_file(J.USERS_FILEPATH)
+	var users_json: Variant = read_json_from_file(J.global.env_server_json_backend_file)
 	var error: String = ""
 
 	if users_json == null:
-		J.logger.warn("Could not json parse content of %s" % J.USERS_FILEPATH)
+		J.logger.warn("Could not json parse content of %s" % J.global.env_server_json_backend_file)
 		return {"result": false, "error": "Oops something went wrong"}
 
 	if username in users_json:
@@ -57,7 +57,7 @@ func CreateAccount(username: String, password: String) -> Dictionary:
 
 	users_json[username] = {"password": password}
 
-	if not write_json_to_file(J.USERS_FILEPATH, users_json):
+	if not write_json_to_file(J.global.env_server_json_backend_file, users_json):
 		J.logger.warn("Could not store new user")
 		return {"result": false, "error": "Oops something went wrong"}
 
@@ -67,9 +67,9 @@ func CreateAccount(username: String, password: String) -> Dictionary:
 
 
 func AuthenticateUser(username: String, password: String) -> bool:
-	var users_json = read_json_from_file(J.USERS_FILEPATH)
+	var users_json = read_json_from_file(J.global.env_server_json_backend_file)
 	if users_json == null:
-		J.logger.warn("Could not json parse content of %s" % J.USERS_FILEPATH)
+		J.logger.warn("Could not json parse content of %s" % J.global.env_server_json_backend_file)
 		return false
 
 	return (
@@ -80,9 +80,9 @@ func AuthenticateUser(username: String, password: String) -> bool:
 
 
 func StorePlayerData(username: String, data: Dictionary) -> bool:
-	var users_json = read_json_from_file(J.USERS_FILEPATH)
+	var users_json = read_json_from_file(J.global.env_server_json_backend_file)
 	if users_json == null:
-		J.logger.warn("Could not json parse content of %s" % J.USERS_FILEPATH)
+		J.logger.warn("Could not json parse content of %s" % J.global.env_server_json_backend_file)
 		return false
 
 	if not username in users_json:
@@ -91,7 +91,7 @@ func StorePlayerData(username: String, data: Dictionary) -> bool:
 
 	users_json[username]["data"] = data
 
-	if not write_json_to_file(J.USERS_FILEPATH, users_json):
+	if not write_json_to_file(J.global.env_server_json_backend_file, users_json):
 		J.logger.warn("Could not store player=[]'s data" % username)
 		return false
 
@@ -99,9 +99,9 @@ func StorePlayerData(username: String, data: Dictionary) -> bool:
 
 
 func LoadPlayerData(username: String) -> Dictionary:
-	var users_json = read_json_from_file(J.USERS_FILEPATH)
+	var users_json = read_json_from_file(J.global.env_server_json_backend_file)
 	if users_json == null:
-		J.logger.warn("Could not json parse content of %s" % J.USERS_FILEPATH)
+		J.logger.warn("Could not json parse content of %s" % J.global.env_server_json_backend_file)
 		return {}
 
 	if not username in users_json:

--- a/scripts/network/database/database.gd
+++ b/scripts/network/database/database.gd
@@ -19,7 +19,7 @@ func init() -> bool:
 			add_child(backend)
 
 	if not backend or not backend.Init():
-		J.logger.err("Failed to init database")
+		J.logger.error("Failed to init database")
 		return false
 
 	return true

--- a/scripts/network/server.gd
+++ b/scripts/network/server.gd
@@ -18,7 +18,7 @@ func init() -> bool:
 	add_child(database)
 
 	if not database.init():
-		J.logger.err("Failed to init server's database")
+		J.logger.error("Failed to init server's database")
 		return false
 
 	return true

--- a/scripts/singletons/jdungeon.gd
+++ b/scripts/singletons/jdungeon.gd
@@ -15,8 +15,6 @@ const DROP_RANGE = 64
 const PERSISTENCY_INTERVAL = 60.0
 const PLAYER_RESPAWN_TIME = 10.0
 
-const USERS_FILEPATH = "data/users.json"
-
 var mode: MODE = MODE.CLIENT
 
 var logger: Log


### PR DESCRIPTION
Fixes:
https://github.com/jonathaneeckhout/jdungeon/issues/85

Additional fix:
I've made it so that depending on what backend is chosen you require certain env variables.

How to test this fix:
Test 1:
Set your backend to "json" and modify the .env variable SERVER_JSON_BACKEND_FILE to a location you prefer and have write access to. When creating accounts and closing the client, all persistent data should be stored in the new location.

Test 2:
When you set the backend to "json" remove or comment out the following variables from the .env file:
```
POSTGRES_ADDRESS=127.0.0.1
POSTGRES_PORT=5432
POSTGRES_USER=testuser
POSTGRES_PASSWORD=testpassword
POSTGRES_DB=jdungeon
```
The server should start

Test 3: 
When you set the backend to "postgres" remove or comment out the following variable from the .env file:
```
SERVER_JSON_BACKEND_FILE="data/users.json"
```
The server should start
