### PR TITLE
Select run mode via env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ SERVER_JSON_BACKEND_FILE="res://data/users.json"
 
 DEBUG=true
 AUDIO_MUTE=false
+
+# Optional select which mode to run via this .env file
+# RUN_AS_SERVER=true
+# RUN_AS_CLIENT=true

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -10,8 +10,15 @@ func _ready():
 	register_enemies()
 	register_npcs()
 	register_items()
-	
-	parse_cmd_arguments()
+
+	J.global.load_common_env_variables()
+
+	if J.global.env_run_as_server:
+		$SelectRunMode/VBoxContainer/RunAsServerButton.pressed.emit()
+	elif J.global.env_run_as_client:
+		$SelectRunMode/VBoxContainer/RunAsClientButton.pressed.emit()
+	else:
+		parse_cmd_arguments()
 
 
 func register_enemies():
@@ -73,17 +80,18 @@ func register_items():
 		"PlateLegs", "res://scenes/items/equipment/armour/platelegs/PlateLegs.tscn"
 	)
 
+
 func parse_cmd_arguments():
-	var args:PackedStringArray = OS.get_cmdline_args()
+	var args: PackedStringArray = OS.get_cmdline_args()
 	if not args.is_empty():
 		J.logger.info("Found launch arguments. ", str(args))
-		
+
 	for arg in args:
 		match arg:
 			"j_client":
 				$SelectRunMode/VBoxContainer/RunAsClientButton.pressed.emit()
 				break
-				
+
 			"j_server":
 				$SelectRunMode/VBoxContainer/RunAsServerButton.pressed.emit()
 				break

--- a/scripts/global.gd
+++ b/scripts/global.gd
@@ -1,5 +1,8 @@
 extends Node
 
+var env_run_as_server: bool = false
+var env_run_as_client: bool = false
+
 var env_server_address: String = ""
 var env_server_port: int = 0
 var env_server_max_peers: int = 0
@@ -34,6 +37,13 @@ func load_local_settings():
 
 	#Set controls
 	InputRemapping.load_mappings()
+
+
+func load_common_env_variables() -> bool:
+	env_run_as_server = J.env.get_value("RUN_AS_SERVER") == "true"
+	env_run_as_client = J.env.get_value("RUN_AS_CLIENT") == "true"
+
+	return true
 
 
 func load_server_env_variables() -> bool:


### PR DESCRIPTION
New:

Introducing the env variables

RUN_AS_SERVER
RUN_AS_CLIENT

Setting these env variables to true will select the run mode accordingly.

Is optional thus ignored when not set.

This has higher priority than the command line arguments