### PR TITLE
network cleanup

### DIFF
--- a/scenes/enemies/TreeTrunkGuy/TreeTrunkGuy.gd
+++ b/scenes/enemies/TreeTrunkGuy/TreeTrunkGuy.gd
@@ -34,6 +34,7 @@ func _ready():
 	if J.is_server():
 		beehave_tree.enabled = true
 	stats.max_hp = 50
+	stats.hp = stats.max_hp
 	synchronizer.loop_animation_changed.connect(_on_loop_animation_changed)
 	synchronizer.got_hurt.connect(_on_got_hurt)
 	synchronizer.died.connect(_on_died)

--- a/scenes/enemies/common/ai/sequences/attack_sequence/ShouldAttack.gd
+++ b/scenes/enemies/common/ai/sequences/attack_sequence/ShouldAttack.gd
@@ -3,6 +3,8 @@ extends ConditionLeaf
 
 func tick(actor: Node, blackboard: Blackboard):
 	var target: JBody2D = blackboard.get_value("aggro_target")
+	if not is_instance_valid(target):
+		return FAILURE
 	if actor.global_position.distance_to(target.global_position) <= actor.stats.attack_range:
 		actor.destination = actor.global_position
 		return SUCCESS

--- a/scenes/enemies/common/ai/sequences/pursuit_sequence/ShouldPursue.gd
+++ b/scenes/enemies/common/ai/sequences/pursuit_sequence/ShouldPursue.gd
@@ -3,5 +3,7 @@ extends ConditionLeaf
 
 func tick(_actor: Node, blackboard: Blackboard) -> int:
 	var aggro_target: JBody2D = blackboard.get_value("aggro_target")
+	if not is_instance_valid(aggro_target):
+		return FAILURE
 	blackboard.set_value("destination_global_position", aggro_target.global_position)
 	return SUCCESS

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -25,42 +25,55 @@ extends JPlayerBody2D
 }
 
 
-func _ready():
+func _init():
+	super()
 	stats.max_hp = 50
+	stats.hp = stats.max_hp
+
+
+func _ready():
 	synchronizer.loop_animation_changed.connect(_on_loop_animation_changed)
 	synchronizer.attacked.connect(_on_attacked)
 	synchronizer.healed.connect(_on_healed)
 	synchronizer.got_hurt.connect(_on_got_hurt)
 
+	equipment.loaded.connect(_on_equipment_loaded)
 	equipment.item_added.connect(_on_item_equiped)
 	equipment.item_removed.connect(_on_item_unequiped)
+
+	stats.synced.connect(_on_stats_synced)
+
+	synchronizer.died.connect(_on_died)
+	synchronizer.respawned.connect(_on_respawned)
 
 	animation_player.play(loop_animation)
 
 	$JInterface.display_name = username
 
-	if J.is_server() or peer_id != multiplayer.get_unique_id():
+	super()
+
+	if J.is_server():
+		# No input is handeld on server's side
 		set_process_input(false)
+		# Remove the camera with ui on the server's side
 		$Camera2D.queue_free()
+
+		$JInterface.update_hp_bar(stats.hp, stats.max_hp)
 		# Make sure to load equipment on server side
 		equipment_changed()
 	else:
-		$Camera2D/UILayer/GUI/Inventory.register_signals()
-		$Camera2D/UILayer/GUI/Equipment.register_signals()
+		if peer_id != multiplayer.get_unique_id():
+			# No input is handeld on other player's side
+			set_process_input(false)
+			# Remove the camera with ui on the other player's side
+			$Camera2D.queue_free()
 
-		# Get the current stats of the player
-		stats.synced.connect(_on_stats_synced)
-		stats.get_sync.rpc_id(1, peer_id)
-
-		# Get the current equipment of the player:
-		equipment.loaded.connect(_on_equipment_loaded)
-		equipment.sync_equipment.rpc_id(1)
+		else:
+			$Camera2D/UILayer/GUI/Inventory.register_signals()
+			$Camera2D/UILayer/GUI/Equipment.register_signals()
 
 		synchronizer.experience_gained.connect(_on_experience_gained)
 		synchronizer.level_gained.connect(_on_level_gained)
-
-		synchronizer.died.connect(_on_died)
-		synchronizer.respawned.connect(_on_respawned)
 
 
 func _physics_process(_delta):
@@ -193,8 +206,10 @@ func _on_item_unequiped(_item_uuid: String):
 
 func _on_stats_synced():
 	$JInterface.update_hp_bar(stats.hp, stats.max_hp)
-	update_exp_bar()
-	update_level()
+
+	if not J.is_server() and peer_id == multiplayer.get_unique_id():
+		update_exp_bar()
+		update_level()
 
 
 func _on_experience_gained(_from: String, _current_exp: int, amount: int):
@@ -211,14 +226,20 @@ func _on_level_gained(_current_level: int, _amount: int, _experience_needed: int
 
 
 func _on_died():
-	$Camera2D/UILayer/GUI/DeathPopup.show_popup()
+	if not J.is_server() and peer_id == multiplayer.get_unique_id():
+		$Camera2D/UILayer/GUI/DeathPopup.show_popup()
+
 	animation_player.stop()
 	animation_player.play("Die")
 
 
 func _on_respawned():
-	$Camera2D/UILayer/GUI/DeathPopup.hide()
-	# Fetch your new hp
-	stats.get_sync.rpc_id(1, peer_id)
 	loop_animation = "Idle"
 	animation_player.play(loop_animation)
+
+	# Fetch your new hp
+	if not J.is_server():
+		if peer_id == multiplayer.get_unique_id():
+			$Camera2D/UILayer/GUI/DeathPopup.hide()
+
+		stats.sync_stats.rpc_id(1, peer_id)

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -33,103 +33,110 @@ login_panel = NodePath("../LoginPanel")
 [node name="TreeTrunkGuy" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2164, 1328)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy2" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2590, 276)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy3" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-3139, 1193)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy8" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-3584, 1706)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy9" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-4239, 1075)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy10" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-4691, 1501)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy11" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-5313, 414)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy13" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-5678, -701)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy14" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-5029, -1043)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy15" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-4816, -611)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy16" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-3994, -1151)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy17" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-3149, -1262)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy12" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-5405, 1397)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy4" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2216, -599)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy6" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-1807, -1317)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="TreeTrunkGuy7" parent="Entities/Enemies" instance=ExtResource("3_fddk3")]
 position = Vector2(-2022, -995)
 should_respawn = true
-respawn_time = null
+respawn_time = 20.0
 
 [node name="Sheep6" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]
 position = Vector2(-1008, -404)
+should_respawn = true
 
 [node name="Sheep8" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]
 position = Vector2(-1243, -243)
+should_respawn = true
 
 [node name="Sheep9" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]
 position = Vector2(-1216, 391)
+should_respawn = true
 
 [node name="Sheep10" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]
 position = Vector2(-814, 495)
+should_respawn = true
 
 [node name="Sheep11" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]
 position = Vector2(-1497, 606)
+should_respawn = true
 
 [node name="Sheep12" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]
 position = Vector2(-1424, -650)
+should_respawn = true
 
 [node name="Sheep13" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]
 position = Vector2(-884, -759)
+should_respawn = true
 
 [node name="Sheep7" parent="Entities/Enemies" instance=ExtResource("4_uubdx")]
 position = Vector2(-1104, 89)

--- a/scripts/classes/JBody2D.gd
+++ b/scripts/classes/JBody2D.gd
@@ -34,6 +34,11 @@ func _init():
 	add_child(stats)
 
 
+func _ready():
+	if not J.is_server() and J.client.player:
+		stats.sync_stats.rpc_id(1, J.client.player.peer_id)
+
+
 func attack(target: CharacterBody2D):
 	var damage = randi_range(stats.attack_power_min, stats.attack_power_max)
 

--- a/scripts/classes/JEnemyBody2D.gd
+++ b/scripts/classes/JEnemyBody2D.gd
@@ -29,11 +29,6 @@ func _init():
 		add_child(despawn_timer)
 
 
-func _ready():
-	if not J.is_server() and J.client.player:
-		stats.get_sync.rpc_id(1, J.client.player.peer_id)
-
-
 func die():
 	super()
 

--- a/scripts/classes/JEquipment.gd
+++ b/scripts/classes/JEquipment.gd
@@ -32,7 +32,8 @@ func equip_item(item: JItem) -> bool:
 		unequip_item(items[item.equipment_slot].uuid)
 
 	if _equip_item(item):
-		sync_equip_item.rpc_id(player.peer_id, item.uuid, item.item_class)
+		for watcher in player.synchronizer.watchers:
+			sync_equip_item.rpc_id(watcher.peer_id, item.uuid, item.item_class)
 
 		item_added.emit(item.uuid, item.item_class)
 
@@ -57,7 +58,8 @@ func _equip_item(item: JItem) -> bool:
 func unequip_item(item_uuid: String) -> JItem:
 	var item: JItem = _unequip_item(item_uuid)
 	if item:
-		sync_unequip_item.rpc_id(player.peer_id, item.uuid)
+		for watcher in player.synchronizer.watchers:
+			sync_unequip_item.rpc_id(watcher.peer_id, item.uuid)
 
 		item_removed.emit(item_uuid)
 
@@ -134,13 +136,17 @@ func _on_equipment_item_removed(id: int, item_uuid: String):
 	unequip_item(item_uuid)
 
 
-@rpc("call_remote", "any_peer", "reliable") func sync_equipment():
+@rpc("call_remote", "any_peer", "reliable") func sync_equipment(id: int):
 	if not J.is_server():
 		return
 
-	var id = multiplayer.get_remote_sender_id()
+	var caller_id = multiplayer.get_remote_sender_id()
 
-	if id == player.peer_id:
+	# Only allow logged in players
+	if not J.server.is_user_logged_in(caller_id):
+		return
+
+	if id in multiplayer.get_peers():
 		sync_response.rpc_id(id, to_json())
 
 

--- a/scripts/classes/JInventory.gd
+++ b/scripts/classes/JInventory.gd
@@ -173,6 +173,10 @@ func _on_inventory_item_dropped(id: int, item_uuid: String):
 
 	var id = multiplayer.get_remote_sender_id()
 
+	# Only allow logged in players
+	if not J.server.is_user_logged_in(id):
+		return
+
 	if id == player.peer_id:
 		sync_response.rpc_id(id, to_json())
 

--- a/scripts/classes/JPlayerBody2D.gd
+++ b/scripts/classes/JPlayerBody2D.gd
@@ -70,6 +70,13 @@ func _init():
 		player_input.interact.connect(_on_interact)
 
 
+func _ready():
+	super()
+
+	if not J.is_server() and J.client.player:
+		equipment.sync_equipment.rpc_id(1, J.client.player.peer_id)
+
+
 func die():
 	super()
 

--- a/scripts/classes/JPlayerSynchronizer.gd
+++ b/scripts/classes/JPlayerSynchronizer.gd
@@ -62,13 +62,18 @@ func _on_body_network_view_area_body_entered(body: JBody2D):
 	if not bodies_in_view.has(body):
 		match body.entity_type:
 			J.ENTITY_TYPE.PLAYER:
-				J.rpcs.player.add_other_player.rpc_id(player.peer_id, body.username, body.position)
+				J.rpcs.player.add_other_player.rpc_id(
+					player.peer_id, body.username, body.position, body.loop_animation
+				)
 			J.ENTITY_TYPE.ENEMY:
 				J.rpcs.enemy.add_enemy.rpc_id(
-					player.peer_id, body.name, body.enemy_class, body.position
+					player.peer_id, body.name, body.enemy_class, body.position, body.loop_animation
 				)
 			J.ENTITY_TYPE.NPC:
-				J.rpcs.npc.add_npc.rpc_id(player.peer_id, body.name, body.npc_class, body.position)
+				J.rpcs.npc.add_npc.rpc_id(
+					player.peer_id, body.name, body.npc_class, body.position, body.loop_animation
+				)
+
 		bodies_in_view.append(body)
 
 	if player not in body.synchronizer.watchers:
@@ -120,6 +125,10 @@ func _on_item_network_view_area_body_exited(body: JItem):
 
 	var id = multiplayer.get_remote_sender_id()
 
+	# Only allow logged in players
+	if not J.server.is_user_logged_in(id):
+		return
+
 	if id == player.peer_id:
 		moved.emit(pos)
 
@@ -129,6 +138,10 @@ func _on_item_network_view_area_body_exited(body: JItem):
 		return
 
 	var id = multiplayer.get_remote_sender_id()
+
+	# Only allow logged in players
+	if not J.server.is_user_logged_in(id):
+		return
 
 	if id == player.peer_id:
 		interacted.emit(target)

--- a/scripts/classes/JStats.gd
+++ b/scripts/classes/JStats.gd
@@ -9,11 +9,9 @@ const BASE_EXPERIENCE = 100
 
 @export var parent: JBody2D
 
-var max_hp: int = 10:
-	set(new_max_hp):
-		max_hp = new_max_hp
-		hp = max_hp
+var max_hp: int = 10
 var hp: int = max_hp
+
 var attack_power_min: int = 0
 var attack_power_max: int = 10
 var attack_speed: float = 0.8
@@ -109,15 +107,21 @@ func add_experience(from: String, amount: int):
 	parent.synchronizer.sync_experience(from, experience, amount)
 
 
-@rpc("call_remote", "any_peer", "reliable") func get_sync(id: int):
+@rpc("call_remote", "any_peer", "reliable") func sync_stats(id: int):
 	if not J.is_server():
 		return
 
+	var caller_id = multiplayer.get_remote_sender_id()
+
+	# Only allow logged in players
+	if not J.server.is_user_logged_in(caller_id):
+		return
+
 	if id in multiplayer.get_peers():
-		sync.rpc_id(id, to_json())
+		sync_response.rpc_id(id, to_json())
 
 
-@rpc("call_remote", "authority", "unreliable") func sync(data: Dictionary):
+@rpc("call_remote", "authority", "unreliable") func sync_response(data: Dictionary):
 	max_hp = data["max_hp"]
 	hp = data["hp"]
 	level = data["level"]

--- a/scripts/classes/JWorld.gd
+++ b/scripts/classes/JWorld.gd
@@ -181,16 +181,17 @@ func _on_client_player_added(id: int, username: String, pos: Vector2):
 
 	player.position = pos
 
-	players.add_child(player)
-
 	J.client.player = player
 
+	players.add_child(player)
 
-func _on_client_other_player_added(username: String, pos: Vector2):
+
+func _on_client_other_player_added(username: String, pos: Vector2, loop_animation: String):
 	var player = J.player_scene.instantiate()
 	player.name = username
 	player.username = username
 	player.position = pos
+	player.loop_animation = loop_animation
 
 	players.add_child(player)
 
@@ -200,10 +201,13 @@ func _on_client_other_player_removed(username: String):
 		players.get_node(username).queue_free()
 
 
-func _on_client_enemy_added(enemy_name: String, enemy_class: String, pos: Vector2):
+func _on_client_enemy_added(
+	enemy_name: String, enemy_class: String, pos: Vector2, loop_animation: String
+):
 	var enemy: JEnemyBody2D = J.enemy_scenes[enemy_class].instantiate()
 	enemy.name = enemy_name
 	enemy.position = pos
+	enemy.loop_animation = loop_animation
 
 	enemies.add_child(enemy)
 
@@ -213,10 +217,13 @@ func _on_client_enemy_removed(enemy_name: String):
 		enemies.get_node(enemy_name).queue_free()
 
 
-func _on_client_npc_added(npc_name: String, npc_class: String, pos: Vector2):
+func _on_client_npc_added(
+	npc_name: String, npc_class: String, pos: Vector2, loop_animation: String
+):
 	var npc: JNPCBody2D = J.npc_scenes[npc_class].instantiate()
 	npc.name = npc_name
 	npc.position = pos
+	npc.loop_animation = loop_animation
 
 	npcs.add_child(npc)
 

--- a/scripts/godotenv/scripts/env.gd
+++ b/scripts/godotenv/scripts/env.gd
@@ -15,14 +15,14 @@ func get_value(valuename: String):
 		J.logger.info("Getting environment value=[%s]" % valuename)
 		return env[valuename]
 
-	J.logger.warn("Could not find environment value=[%s]" % valuename)
+	J.logger.info("Could not find environment value=[%s]" % valuename)
 	# return empty
 	return ""
 
 
 func parse(filename:String):
 	if !FileAccess.file_exists(filename):
-		J.logger.warn("File=[%s] does not exist" % filename)
+		J.logger.info("File=[%s] does not exist" % filename)
 		return {}
 
 	var file:FileAccess = FileAccess.open(filename, FileAccess.READ)

--- a/scripts/network/rpcs/enemy.gd
+++ b/scripts/network/rpcs/enemy.gd
@@ -1,11 +1,11 @@
 extends Node
 
-signal enemy_added(enemy_name: String, enemy_class: String, pos: Vector2)
+signal enemy_added(enemy_name: String, enemy_class: String, pos: Vector2, loop_animation: String)
 signal enemy_removed(enemy_name: String)
 
 @rpc("call_remote", "authority", "reliable")
-func add_enemy(enemy_name: String, enemy_class: String, pos: Vector2):
-	enemy_added.emit(enemy_name, enemy_class, pos)
+func add_enemy(enemy_name: String, enemy_class: String, pos: Vector2, loop_animation: String):
+	enemy_added.emit(enemy_name, enemy_class, pos, loop_animation)
 
 
 @rpc("call_remote", "authority", "reliable") func remove_enemy(enemy_name: String):

--- a/scripts/network/rpcs/npc.gd
+++ b/scripts/network/rpcs/npc.gd
@@ -1,14 +1,14 @@
 extends Node
 
-signal npc_added(npc_name: String, npc_class: String, pos: Vector2)
+signal npc_added(npc_name: String, npc_class: String, pos: Vector2, loop_animation: String)
 signal npc_removed(npc_name: String)
 
 signal shop_updated(vendor: String, shop: Dictionary)
 signal shop_item_bought(id: int, vendor: String, item_uuid: String)
 
 @rpc("call_remote", "authority", "reliable")
-func add_npc(npc_name: String, npc_class: String, pos: Vector2):
-	npc_added.emit(npc_name, npc_class, pos)
+func add_npc(npc_name: String, npc_class: String, pos: Vector2, loop_animation: String):
+	npc_added.emit(npc_name, npc_class, pos, loop_animation)
 
 
 @rpc("call_remote", "authority", "reliable") func remove_npc(npc_name: String):

--- a/scripts/network/rpcs/player.gd
+++ b/scripts/network/rpcs/player.gd
@@ -1,7 +1,7 @@
 extends Node
 
 signal player_added(id: int, username: String, pos: Vector2)
-signal other_player_added(username: String, pos: Vector2)
+signal other_player_added(username: String, pos: Vector2, loop_animation: String)
 signal other_player_removed(username: String)
 signal message_sent(from: int, type: String, to: String, message: String)
 signal message_received(type: String, from: String, message: String)
@@ -11,8 +11,9 @@ func add_player(id: int, username: String, pos: Vector2):
 	player_added.emit(id, username, pos)
 
 
-@rpc("call_remote", "authority", "reliable") func add_other_player(username: String, pos: Vector2):
-	other_player_added.emit(username, pos)
+@rpc("call_remote", "authority", "reliable")
+func add_other_player(username: String, pos: Vector2, loop_animation: String):
+	other_player_added.emit(username, pos, loop_animation)
 
 
 @rpc("call_remote", "authority", "reliable") func remove_other_player(username: String):


### PR DESCRIPTION
Fix:
- prevent not logged in players to call rpcs
- sync equiping and unequiping items to other players
- fix invalid target access
- fix hp persistency
- sync hp to other players
- set respawn time on treetrunkguys
- properly sync stats
- sync equipment to only the player watching you
- lower loglevel
- sync initial loop animation
