### PR TITLE
Changed how entities collide with each other (fixes players pushing each other)

### DIFF
--- a/scenes/enemies/common/ai/conditionals/is_in_combat/IsInCombat.gd
+++ b/scenes/enemies/common/ai/conditionals/is_in_combat/IsInCombat.gd
@@ -3,6 +3,7 @@ extends ConditionLeaf
 @export var aggro_radius: Area2D = null
 @export var should_leash := false
 @export var leash_distance: float = 350.0
+@export var targetable_entity_type: J.ENTITY_TYPE = J.ENTITY_TYPE.PLAYER
 @onready var reset_timer: Timer = $ResetTimer
 var start_combat := false
 var in_combat := false
@@ -50,7 +51,7 @@ func tick(actor: Node, blackboard: Blackboard):
 
 
 func _on_body_entered(body: Node2D):
-	if target == null:
+	if target == null and body.get("entity_type") == targetable_entity_type:
 		start_combat = true
 		target = body
 

--- a/scripts/classes/JBody2D.gd
+++ b/scripts/classes/JBody2D.gd
@@ -24,9 +24,10 @@ func _init():
 	stats.name = "Stats"
 	stats.parent = self
 	add_child(stats)
-	
+
 	#Call this at the last moment, prevents possible errors from non-ready collisions and allows overriden _init methods to run first.
 	_init_collisions.call_deferred()
+
 
 func _init_collisions():
 	#Each creature only exists on their own layer, they collide with the world thanks to their collision_mask
@@ -37,28 +38,28 @@ func _init_collisions():
 			collision_layer = J.PHYSICS_LAYER_ENEMIES
 		J.ENTITY_TYPE.NPC:
 			collision_layer = J.PHYSICS_LAYER_NPCS
-			
+
 	if J.is_server():
 		#By default, only collide with the world. No other entities.
 		collision_mask = J.PHYSICS_LAYER_WORLD
-		
+
 		#Set what it will collide with
 		match entity_type:
 			#The player cannot walk past NPCs and enemies. But other players cannot block their path.
 			J.ENTITY_TYPE.PLAYER:
 				collision_mask += J.PHYSICS_LAYER_ENEMIES + J.PHYSICS_LAYER_NPCS
-			
+
 			#Enemies can be blocked by NPCs and players.
 			J.ENTITY_TYPE.ENEMY:
 				collision_mask += J.PHYSICS_LAYER_PLAYERS + J.PHYSICS_LAYER_NPCS
-				
+
 			#NPCs cannot be stopped by any entity.
 			J.ENTITY_TYPE.NPC:
 				collision_mask = 0
 	else:
 		# Don't handle collision on client side
 		collision_mask = 0
-	
+
 
 func attack(target: CharacterBody2D):
 	var damage = randi_range(stats.attack_power_min, stats.attack_power_max)

--- a/scripts/classes/JBody2D.gd
+++ b/scripts/classes/JBody2D.gd
@@ -15,14 +15,6 @@ var is_dead := false
 
 
 func _init():
-	collision_layer = J.PHYSICS_LAYER_WORLD
-
-	if J.is_server():
-		collision_mask = J.PHYSICS_LAYER_WORLD
-	else:
-		# Don't handle collision on client side
-		collision_mask = 0
-
 	synchronizer = load("res://scripts/classes/JSynchronizer.gd").new()
 	synchronizer.name = "Synchronizer"
 	synchronizer.to_be_synced = self
@@ -32,7 +24,41 @@ func _init():
 	stats.name = "Stats"
 	stats.parent = self
 	add_child(stats)
+	
+	#Call this at the last moment, prevents possible errors from non-ready collisions and allows overriden _init methods to run first.
+	_init_collisions.call_deferred()
 
+func _init_collisions():
+	#Each creature only exists on their own layer, they collide with the world thanks to their collision_mask
+	match entity_type:
+		J.ENTITY_TYPE.PLAYER:
+			collision_layer = J.PHYSICS_LAYER_PLAYERS
+		J.ENTITY_TYPE.ENEMY:
+			collision_layer = J.PHYSICS_LAYER_ENEMIES
+		J.ENTITY_TYPE.NPC:
+			collision_layer = J.PHYSICS_LAYER_NPCS
+			
+	if J.is_server():
+		#By default, only collide with the world. No other entities.
+		collision_mask = J.PHYSICS_LAYER_WORLD
+		
+		#Set what it will collide with
+		match entity_type:
+			#The player cannot walk past NPCs and enemies. But other players cannot block their path.
+			J.ENTITY_TYPE.PLAYER:
+				collision_mask += J.PHYSICS_LAYER_ENEMIES + J.PHYSICS_LAYER_NPCS
+			
+			#Enemies can be blocked by NPCs and players.
+			J.ENTITY_TYPE.ENEMY:
+				collision_mask += J.PHYSICS_LAYER_PLAYERS + J.PHYSICS_LAYER_NPCS
+				
+			#NPCs cannot be stopped by any entity.
+			J.ENTITY_TYPE.NPC:
+				collision_mask = 0
+	else:
+		# Don't handle collision on client side
+		collision_mask = 0
+	
 
 func attack(target: CharacterBody2D):
 	var damage = randi_range(stats.attack_power_min, stats.attack_power_max)

--- a/scripts/classes/JEnemyBody2D.gd
+++ b/scripts/classes/JEnemyBody2D.gd
@@ -19,8 +19,6 @@ func _init():
 
 	entity_type = J.ENTITY_TYPE.ENEMY
 
-	collision_layer += J.PHYSICS_LAYER_ENEMIES
-
 	if J.is_server():
 		despawn_timer = Timer.new()
 		despawn_timer.name = "DespawnTimer"

--- a/scripts/classes/JNPCBody2D.gd
+++ b/scripts/classes/JNPCBody2D.gd
@@ -14,8 +14,6 @@ func _init():
 
 	entity_type = J.ENTITY_TYPE.NPC
 
-	collision_layer += J.PHYSICS_LAYER_NPCS
-
 	if J.is_server():
 		shop = JShop.new()
 		shop.name = "Shop"

--- a/scripts/classes/JPlayerBody2D.gd
+++ b/scripts/classes/JPlayerBody2D.gd
@@ -20,8 +20,6 @@ func _init():
 
 	entity_type = J.ENTITY_TYPE.PLAYER
 
-	collision_layer += J.PHYSICS_LAYER_PLAYERS
-
 	player_synchronizer = JPlayerSynchronizer.new()
 	player_synchronizer.name = "PlayerSynchronizer"
 	player_synchronizer.player = self


### PR DESCRIPTION
Players are stopped by NPCs and enemies.   
Enemies are stopped by NPCs and players.  
NPCs are not stopped by anything.
They all still collide with the world.  
  
Entities no longer exist on the J.PHYSICS_LAYER_WORLD and merely use their mask to collide with it.      
    
It was necessary to add the ability for the ConditionLeaf "IsInCombat" to filter targets by type instead of choosing ANYTHING entering their area. (it caused enemies to attack each other lol)  

Tests performed:  
- Try to aggro multiple enemies, they will not block each other and will just walk trough. They will still collide with the player.  
- Attempt to get in the path of a moving NPC, the NPC just pushes you aside  