### PR TITLE
Fixed attempting to select between server and client mode while playing.

### DIFF
--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -21,19 +21,6 @@ func _ready():
 		parse_cmd_arguments()
 
 
-func _input(event: InputEvent) -> void:
-	if get_meta("PRESSED", false):
-		return
-
-	if event.is_action_pressed("j_slot1"):
-		set_meta("PRESSED", true)
-		_on_run_as_server_pressed()
-
-	elif event.is_action_pressed("j_slot2"):
-		_on_run_as_client_pressed()
-		set_meta("PRESSED", true)
-
-
 func register_enemies():
 	J.register_enemy_scene("Sheep", "res://scenes/enemies/Sheep/Sheep.tscn")
 	J.register_enemy_scene("TreeTrunkGuy", "res://scenes/enemies/TreeTrunkGuy/TreeTrunkGuy.tscn")

--- a/scenes/root/Root.tscn
+++ b/scenes/root/Root.tscn
@@ -1,6 +1,20 @@
-[gd_scene load_steps=2 format=3 uid="uid://6xcgrn54y7si"]
+[gd_scene load_steps=6 format=3 uid="uid://6xcgrn54y7si"]
 
 [ext_resource type="Script" path="res://scenes/root/Root.gd" id="1_2xin5"]
+
+[sub_resource type="InputEventAction" id="InputEventAction_ple52"]
+action = &"j_slot1"
+pressed = true
+
+[sub_resource type="Shortcut" id="Shortcut_jdnlo"]
+events = [SubResource("InputEventAction_ple52")]
+
+[sub_resource type="InputEventAction" id="InputEventAction_js6rf"]
+action = &"j_slot2"
+pressed = true
+
+[sub_resource type="Shortcut" id="Shortcut_lgvw8"]
+events = [SubResource("InputEventAction_js6rf")]
 
 [node name="Root" type="Node"]
 script = ExtResource("1_2xin5")
@@ -30,8 +44,10 @@ grow_vertical = 2
 
 [node name="RunAsServerButton" type="Button" parent="SelectRunMode/VBoxContainer"]
 layout_mode = 2
+shortcut = SubResource("Shortcut_jdnlo")
 text = "1 - Run as server"
 
 [node name="RunAsClientButton" type="Button" parent="SelectRunMode/VBoxContainer"]
 layout_mode = 2
+shortcut = SubResource("Shortcut_lgvw8")
 text = "2 - Run as client"


### PR DESCRIPTION
The crash happened because the buttons are removed after the mode is selected. And you're not supposed to be able to change modes afterwards either.  
Now it uses the "shortcut" property which is part of the Button itself. 