### PR TITLE
Introduce a debug_mode for more verbose output. 

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -141,6 +141,11 @@ j_slot_deselect={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":124,"echo":false,"script":null)
 ]
 }
+debug_mode_toggle={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194332,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
 
 [internationalization]
 

--- a/scripts/singletons/global.gd
+++ b/scripts/singletons/global.gd
@@ -55,8 +55,6 @@ var debug_mode: bool:
 func _ready():
 	#Do not listen to inputs in non-debug builds, for performance reasons.
 	set_process_unhandled_input(OS.is_debug_build())
-	#Start with it enabled if on a debug build
-	debug_mode = OS.is_debug_build()
 
 	env = GodotEnv.new()
 

--- a/scripts/singletons/global.gd
+++ b/scripts/singletons/global.gd
@@ -1,5 +1,7 @@
 extends Node
 
+signal debug_mode_toggled(newStats: bool)
+
 var env_debug: bool = false
 var env_audio_mute: bool = false
 var env_version_file: String = ""
@@ -42,11 +44,28 @@ var env_postgress_db: String = ""
 
 var env: GodotEnv
 
+## This is used to increase/reduce output in some classes.
+var debug_mode: bool:
+	set(val):
+		debug_mode = val
+		print_debug("Debug mode: " + str(debug_mode))
+		debug_mode_toggled.emit(debug_mode)
+
 
 func _ready():
+	#Do not listen to inputs in non-debug builds, for performance reasons.
+	set_process_unhandled_input(OS.is_debug_build())
+	#Start with it enabled if on a debug build
+	debug_mode = OS.is_debug_build()
+
 	env = GodotEnv.new()
 
 	load_common_env_variables()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("debug_mode_toggle"):
+		debug_mode = !debug_mode
 
 
 func load_local_settings():


### PR DESCRIPTION
Currently only used by SkillComponent. Meant to allow more verbose prints with the option to disable them.  
  
It only works on debug builds (so exports marked as debug or in the editor) and can be toggled with F1 (off by default).  
It's status can be checked with the "Global.debug_mode" boolean.  
  
SkillComponent, while on debug mode, reports any attempts to use a skill, who used it, it's class, the reason of failure (if any) and in which instance of the game it was run by using the name of the window.  
  
![image](https://github.com/jonathaneeckhout/jdungeon/assets/55665720/c2f85e31-fa0f-4795-99fc-d6472ac47b1e)
