### PR TITLE
Improved Boost system to be more reliable

### DIFF
--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -212,7 +212,7 @@ func calculate_and_apply_boosts():
 	var boost: Boost = calculate_level_boost()
 	var equipment_boost: Boost = equipment.get_boost()
 	boost.identifier = "player_general"
-	
+
 	boost.combine_boost(equipment_boost)
 	stats.apply_boost(boost)
 

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -205,15 +205,15 @@ func calculate_level_boost() -> Boost:
 	boost.hp_max = int((stats.level - 1) * PLAYER_HP_GAIN_PER_LEVEL)
 	boost.attack_power_min = int(stats.level * PLAYER_ATTACK_POWER_GAIN_PER_LEVEL)
 	boost.attack_power_max = boost.attack_power_min
+	boost.identifier = "stat_growth_per_level"
 	return boost
 
 
 func calculate_and_apply_boosts():
 	var boost: Boost = calculate_level_boost()
-
 	var equipment_boost: Boost = equipment.get_boost()
-	boost.add_boost(equipment_boost)
-
+	
+	boost.combine_boost(equipment_boost)
 	stats.apply_boost(boost)
 
 

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -205,13 +205,13 @@ func calculate_level_boost() -> Boost:
 	boost.hp_max = int((stats.level - 1) * PLAYER_HP_GAIN_PER_LEVEL)
 	boost.attack_power_min = int(stats.level * PLAYER_ATTACK_POWER_GAIN_PER_LEVEL)
 	boost.attack_power_max = boost.attack_power_min
-	boost.identifier = "stat_growth_per_level"
 	return boost
 
 
 func calculate_and_apply_boosts():
 	var boost: Boost = calculate_level_boost()
 	var equipment_boost: Boost = equipment.get_boost()
+	boost.identifier = "player_general"
 	
 	boost.combine_boost(equipment_boost)
 	stats.apply_boost(boost)

--- a/scenes/player/Player.gd
+++ b/scenes/player/Player.gd
@@ -210,10 +210,11 @@ func calculate_level_boost() -> Boost:
 
 func calculate_and_apply_boosts():
 	var boost: Boost = calculate_level_boost()
+	boost.identifier = "player_level"
 	var equipment_boost: Boost = equipment.get_boost()
-	boost.identifier = "player_general"
+	equipment_boost.identifier = "player_equipment"
 
-	boost.combine_boost(equipment_boost)
+	stats.apply_boost(equipment_boost)
 	stats.apply_boost(boost)
 
 

--- a/scripts/classes/Boost.gd
+++ b/scripts/classes/Boost.gd
@@ -8,39 +8,40 @@ const NO_IDENTIFIER: String = ""
 ## If another boost with this identifier is present, prevent it's addition
 var identifier: String = NO_IDENTIFIER
 
-#Stores an arbitrary amount of values
-var statBoostDict: Dictionary
-var statBoostModifierDict: Dictionary
+## Private. Stores an arbitrary amount of values
+var stat_boost_dict: Dictionary
+## Private. Stores modifiers to be applied to stats. After all flat values have been applied.
+var stat_boost_modifier_dict: Dictionary
 
 var hp_max: int = 0:
 	set(val):
-		statBoostDict["hp_max"] = val
+		stat_boost_dict["hp_max"] = val
 	get:
-		return statBoostDict.get("hp_max", 0 as int)
+		return stat_boost_dict.get("hp_max", 0 as int)
 
 var hp: int = 0:
 	set(val):
-		statBoostDict["hp"] = val
+		stat_boost_dict["hp"] = val
 	get:
-		return statBoostDict.get("hp", 0 as int)
+		return stat_boost_dict.get("hp", 0 as int)
 
 var attack_power_min: int = 0:
 	set(val):
-		statBoostDict["attack_power_min"] = val
+		stat_boost_dict["attack_power_min"] = val
 	get:
-		return statBoostDict.get("attack_power_min", 0 as int)
+		return stat_boost_dict.get("attack_power_min", 0 as int)
 
 var attack_power_max: int = 0:
 	set(val):
-		statBoostDict["attack_power_max"] = val
+		stat_boost_dict["attack_power_max"] = val
 	get:
-		return statBoostDict.get("attack_power_max", 0 as int)
+		return stat_boost_dict.get("attack_power_max", 0 as int)
 
 var defense: int = 0:
 	set(val):
-		statBoostDict["defense"] = val
+		stat_boost_dict["defense"] = val
 	get:
-		return statBoostDict.get("defense", 0 as int)
+		return stat_boost_dict.get("defense", 0 as int)
 
 
 func combine_boost(boost: Boost):
@@ -52,28 +53,32 @@ func combine_boost(boost: Boost):
 					. format([identifier, boost.identifier])
 				)
 			)
-	for stat: String in statBoostDict:
-		set_stat_boost(stat, boost.get_stat_boost(stat))
+			
+	for stat: String in stat_boost_dict:
+		add_stat_boost(stat, boost.get_stat_boost(stat))
+		
+	for stat: String in stat_boost_modifier_dict:
+		add_stat_boost_modifier(stat, boost.get_stat_boost_modifier(stat))
 
 
-func set_stat_boost(statName: String, value: int):
-	statBoostDict[statName] = value
+func set_stat_boost(stat_name: String, value: int):
+	stat_boost_dict[stat_name] = value
 
 
 func add_stat_boost(stat_name: String, value: int):
 	set_stat_boost(stat_name, get_stat_boost(stat_name) + value)
 
 
-func get_stat_boost(statName: String, default: int = 0) -> int:
-	return statBoostDict.get(statName, default)
+func get_stat_boost(stat_name: String, default: int = 0) -> int:
+	return stat_boost_dict.get(stat_name, default)
 
 
 func set_stat_boost_modifier(stat_name: String, value: float):
-	statBoostModifierDict[stat_name] = value
+	stat_boost_modifier_dict[stat_name] = value
 
 
 func get_stat_boost_modifier(stat_name: String, default: float = 1) -> float:
-	return statBoostModifierDict.get(stat_name, default)
+	return stat_boost_modifier_dict.get(stat_name, default)
 
 
 func add_stat_boost_modifier(stat_name: String, value: float, additive: bool = false):

--- a/scripts/classes/Boost.gd
+++ b/scripts/classes/Boost.gd
@@ -47,8 +47,11 @@ func combine_boost(boost: Boost):
 	if Global.debug_mode:
 		if boost.identifier != NO_IDENTIFIER and identifier != NO_IDENTIFIER:
 			GodotLogger.info(
-				"Mixed 2 boosts with differing identifiers (Original '{0}' and incoming '{1}')".format([identifier, boost.identifier])
+				(
+					"Mixed 2 boosts with differing identifiers (Original '{0}' and incoming '{1}')"
+					. format([identifier, boost.identifier])
 				)
+			)
 	for stat: String in statBoostDict:
 		set_stat_boost(stat, boost.get_stat_boost(stat))
 
@@ -63,18 +66,18 @@ func add_stat_boost(stat_name: String, value: int):
 
 func get_stat_boost(statName: String, default: int = 0) -> int:
 	return statBoostDict.get(statName, default)
-	
-	
+
+
 func set_stat_boost_modifier(stat_name: String, value: float):
 	statBoostModifierDict[stat_name] = value
 
 
-func get_stat_boost_modifier(stat_name: String, default:float = 1) -> float:
+func get_stat_boost_modifier(stat_name: String, default: float = 1) -> float:
 	return statBoostModifierDict.get(stat_name, default)
-	
+
+
 func add_stat_boost_modifier(stat_name: String, value: float, additive: bool = false):
 	if additive:
 		set_stat_boost_modifier(stat_name, get_stat_boost_modifier(stat_name) + value)
 	else:
 		set_stat_boost_modifier(stat_name, get_stat_boost_modifier(stat_name) * value)
-	

--- a/scripts/classes/Boost.gd
+++ b/scripts/classes/Boost.gd
@@ -10,6 +10,7 @@ var identifier: String = NO_IDENTIFIER
 
 #Stores an arbitrary amount of values
 var statBoostDict: Dictionary
+var statBoostModifierDict: Dictionary
 
 var hp_max: int = 0:
 	set(val):
@@ -43,6 +44,11 @@ var defense: int = 0:
 
 
 func combine_boost(boost: Boost):
+	if Global.debug_mode:
+		if boost.identifier != NO_IDENTIFIER and identifier != NO_IDENTIFIER:
+			GodotLogger.info(
+				"Mixed 2 boosts with differing identifiers (Original '{0}' and incoming '{1}')".format([identifier, boost.identifier])
+				)
 	for stat: String in statBoostDict:
 		set_stat_boost(stat, boost.get_stat_boost(stat))
 
@@ -51,5 +57,24 @@ func set_stat_boost(statName: String, value: int):
 	statBoostDict[statName] = value
 
 
-func get_stat_boost(statName: String, default: int = 0):
+func add_stat_boost(stat_name: String, value: int):
+	set_stat_boost(stat_name, get_stat_boost(stat_name) + value)
+
+
+func get_stat_boost(statName: String, default: int = 0) -> int:
 	return statBoostDict.get(statName, default)
+	
+	
+func set_stat_boost_modifier(stat_name: String, value: float):
+	statBoostModifierDict[stat_name] = value
+
+
+func get_stat_boost_modifier(stat_name: String, default:float = 1) -> float:
+	return statBoostModifierDict.get(stat_name, default)
+	
+func add_stat_boost_modifier(stat_name: String, value: float, additive: bool = false):
+	if additive:
+		set_stat_boost_modifier(stat_name, get_stat_boost_modifier(stat_name) + value)
+	else:
+		set_stat_boost_modifier(stat_name, get_stat_boost_modifier(stat_name) * value)
+	

--- a/scripts/classes/Boost.gd
+++ b/scripts/classes/Boost.gd
@@ -3,6 +3,11 @@ class_name Boost
 ## This is used to store the boosts a player may obtain. Most common sources being items and status effects.
 ## These are meant to be temporary and may be deleted at any time.
 
+const NO_IDENTIFIER: String = ""
+
+## If another boost with this identifier is present, prevent it's addition
+var identifier: String = NO_IDENTIFIER
+
 #Stores an arbitrary amount of values
 var statBoostDict: Dictionary
 
@@ -37,12 +42,9 @@ var defense: int = 0:
 		return statBoostDict.get("defense", 0 as int)
 
 
-func add_boost(boost: Boost):
-	hp_max += boost.hp_max
-	attack_power_min += boost.attack_power_min
-	attack_power_max += boost.attack_power_max
-
-	defense += boost.defense
+func combine_boost(boost: Boost):
+	for stat: String in statBoostDict:
+		set_stat_boost(stat, boost.get_stat_boost(stat))
 
 
 func set_stat_boost(statName: String, value: int):

--- a/scripts/classes/Boost.gd
+++ b/scripts/classes/Boost.gd
@@ -53,10 +53,10 @@ func combine_boost(boost: Boost):
 					. format([identifier, boost.identifier])
 				)
 			)
-			
+
 	for stat: String in stat_boost_dict:
 		add_stat_boost(stat, boost.get_stat_boost(stat))
-		
+
 	for stat: String in stat_boost_modifier_dict:
 		add_stat_boost_modifier(stat, boost.get_stat_boost_modifier(stat))
 

--- a/scripts/classes/Boost.gd
+++ b/scripts/classes/Boost.gd
@@ -15,33 +15,33 @@ var stat_boost_modifier_dict: Dictionary
 
 var hp_max: int = 0:
 	set(val):
-		stat_boost_dict["hp_max"] = val
+		set_stat_boost("hp_max", val)
 	get:
-		return stat_boost_dict.get("hp_max", 0 as int)
+		return get_stat_boost("hp_max")
 
 var hp: int = 0:
 	set(val):
-		stat_boost_dict["hp"] = val
+		set_stat_boost("hp", val)
 	get:
-		return stat_boost_dict.get("hp", 0 as int)
+		return get_stat_boost("hp")
 
 var attack_power_min: int = 0:
 	set(val):
-		stat_boost_dict["attack_power_min"] = val
+		set_stat_boost("attack_power_min", val)
 	get:
-		return stat_boost_dict.get("attack_power_min", 0 as int)
+		return get_stat_boost("attack_power_min")
 
 var attack_power_max: int = 0:
 	set(val):
-		stat_boost_dict["attack_power_max"] = val
+		set_stat_boost("attack_power_max", val)
 	get:
-		return stat_boost_dict.get("attack_power_max", 0 as int)
+		return get_stat_boost("attack_power_max")
 
 var defense: int = 0:
 	set(val):
-		stat_boost_dict["defense"] = val
+		set_stat_boost("defense", val)
 	get:
-		return stat_boost_dict.get("defense", 0 as int)
+		return get_stat_boost("defense")
 
 
 func combine_boost(boost: Boost):
@@ -54,10 +54,10 @@ func combine_boost(boost: Boost):
 				)
 			)
 
-	for stat: String in stat_boost_dict:
+	for stat: String in boost.stat_boost_dict:
 		add_stat_boost(stat, boost.get_stat_boost(stat))
 
-	for stat: String in stat_boost_modifier_dict:
+	for stat: String in boost.stat_boost_modifier_dict:
 		add_stat_boost_modifier(stat, boost.get_stat_boost_modifier(stat))
 
 

--- a/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
+++ b/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
@@ -390,7 +390,7 @@ func apply_boost(boost: Boost):
 			remove_boost(existingBoost)
 	
 	#Validate boost
-	for statName in boost.statBoostDict:
+	for statName in boost.statBoostDict.keys() + boost.statBoostModifierDict.keys():
 		if not statName in StatListAll:
 			GodotLogger.error("The property '{0}' is not a stat.".format([statName]))
 
@@ -425,10 +425,6 @@ func remove_boost(boost: Boost):
 		GodotLogger.error("This boost does not belong to this component.")
 		return
 
-	#for statName in boost.statBoostDict:
-		#var newValue = get(statName) - boost.get_stat_boost(statName)
-		#self.set(statName, newValue)
-
 	var data: Dictionary = to_json(true)
 
 	if peer_id > 0:
@@ -441,11 +437,22 @@ func remove_boost(boost: Boost):
 
 
 func reload_boosts():
+	load_defaults()
+	
+	var flatValues: Dictionary = {}
+	var modifierValues: Dictionary = {}
+	
 	for stat: String in StatListPermanent:
-		var newValue: int = get("_default_" + stat)
+		flatValues[stat] = 0
+		modifierValues[stat] = 0
 		
 		for boost: Boost in active_boosts:
-			newValue += boost.get_stat_boost(stat)
+			flatValues[stat] += boost.get_stat_boost(stat)
+			modifierValues[stat] += boost.get_stat_boost_modifier(stat)
+			
+		set(stat, flatValues[stat] * modifierValues[stat])
+	
+		
 
 
 func get_boost_with_identifier(identifier: String) -> Boost:

--- a/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
+++ b/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
@@ -463,7 +463,7 @@ func reload_boosts():
 		for boost: Boost in active_boosts:
 			# Store the bonuses of the boost added to the flat amount, as well as the modifiers
 			flat_values[stat] += boost.get_stat_boost(stat)
-			
+
 			# Ignore modifiers of 1.
 			if boost.get_stat_boost_modifier(stat) != 1:
 				modifier_values[stat] *= boost.get_stat_boost_modifier(stat)

--- a/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
+++ b/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
@@ -463,7 +463,10 @@ func reload_boosts():
 		for boost: Boost in active_boosts:
 			# Store the bonuses of the boost added to the flat amount, as well as the modifiers
 			flat_values[stat] += boost.get_stat_boost(stat)
-			modifier_values[stat] *= boost.get_stat_boost_modifier(stat)
+			
+			# Ignore modifiers of 1.
+			if boost.get_stat_boost_modifier(stat) != 1:
+				modifier_values[stat] *= boost.get_stat_boost_modifier(stat)
 
 		# Set the stat to the flat value multiplied by the modifier
 		set(stat, flat_values[stat] * modifier_values[stat])

--- a/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
+++ b/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
@@ -426,7 +426,7 @@ func apply_boost(boost: Boost):
 	boosts_changed.emit()
 
 
-## Attempts to remove a boost per reference. 
+## Attempts to remove a boost per reference.
 func remove_boost(boost: Boost):
 	if not active_boosts.has(boost):
 		GodotLogger.warn("This boost does not belong to this component.")
@@ -451,18 +451,20 @@ func reload_boosts():
 
 	var flat_values: Dictionary = {}
 	var modifier_values: Dictionary = {}
-	
-	#Start iterating trough stats to boost them
+
+	# Start iterating trough stats to boost them
 	for stat: String in StatListPermanent:
 		# Prepare the flat and modifier values that the stat will be set-to and multiplied for.
-		flat_values[stat] = get(stat) #The base value is the current (defaulted) value of the stat 
-		modifier_values[stat] = 1 #The base for modifiers is 1, since it will be multiplied by other modifiers.
+		# The base value is the current (defaulted) value of the stat
+		flat_values[stat] = get(stat)
+		# The base for modifiers is 1, since it will be multiplied by other modifiers.
+		modifier_values[stat] = 1
 
 		for boost: Boost in active_boosts:
 			# Store the bonuses of the boost added to the flat amount, as well as the modifiers
 			flat_values[stat] += boost.get_stat_boost(stat)
 			modifier_values[stat] *= boost.get_stat_boost_modifier(stat)
-		
+
 		# Set the stat to the flat value multiplied by the modifier
 		set(stat, flat_values[stat] * modifier_values[stat])
 

--- a/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
+++ b/scripts/components/networking/statssynchronizercomponent/StatsSynchronizerComponent.gd
@@ -386,32 +386,32 @@ func get_attack_damage() -> float:
 
 ## Adds the [Boost] object to be applied on the stats and synchronizes the addition.
 func apply_boost(boost: Boost):
-	#Override any boost with an identical identifier, ignore if this boost doesn't have one.
+	# Override any boost with an identical identifier, ignore if this boost doesn't have one.
 	if boost.identifier != Boost.NO_IDENTIFIER:
-		var existingBoost: Boost = get_boost_with_identifier(boost.identifier)
-		if existingBoost is Boost:
-			remove_boost(existingBoost)
+		var existing_boost: Boost = get_boost_with_identifier(boost.identifier)
+		if existing_boost is Boost:
+			remove_boost(existing_boost)
 
-	#Validate boost
-	for statName in boost.statBoostDict.keys() + boost.statBoostModifierDict.keys():
-		if not statName in StatListAll:
-			GodotLogger.error("The property '{0}' is not a stat.".format([statName]))
+	# Validate boost
+	for stat_name in boost.stat_boost_dict.keys() + boost.stat_boost_modifier_dict.keys():
+		if not stat_name in StatListAll:
+			GodotLogger.error("The property '{0}' is not a stat.".format([stat_name]))
 
 		if (
-			typeof(boost.get_stat_boost(statName)) != TYPE_INT
-			and typeof(boost.get_stat_boost(statName)) != TYPE_FLOAT
+			typeof(boost.get_stat_boost(stat_name)) != TYPE_INT
+			and typeof(boost.get_stat_boost(stat_name)) != TYPE_FLOAT
 		):
 			(
 				GodotLogger
 				. warn(
 					(
 						"The value type of the boost ({0}) must be type 1 or 2. This could cause unexpected behaviour."
-						. format([typeof(boost.get_stat_boost(statName)), typeof(get(statName))])
+						. format([typeof(boost.get_stat_boost(stat_name)), typeof(get(stat_name))])
 					)
 				)
 			)
 
-	#Add to list
+	# Add to list
 	active_boosts.append(boost)
 
 	var data: Dictionary = to_json(true)
@@ -422,7 +422,7 @@ func apply_boost(boost: Boost):
 	for watcher in watcher_synchronizer.watchers:
 		G.sync_rpc.statssynchronizer_sync_response.rpc_id(watcher.peer_id, target_node.name, data)
 
-	#This signal calls reload_boosts()
+	# This signal calls reload_boosts()
 	boosts_changed.emit()
 
 
@@ -449,36 +449,36 @@ func remove_boost(boost: Boost):
 func reload_boosts():
 	load_defaults()
 
-	var flatValues: Dictionary = {}
-	var modifierValues: Dictionary = {}
+	var flat_values: Dictionary = {}
+	var modifier_values: Dictionary = {}
 	
 	#Start iterating trough stats to boost them
 	for stat: String in StatListPermanent:
-		#Prepare the flat and modifier values that the stat will be set-to and multiplied for.
-		flatValues[stat] = get(stat) #The base value is the current (defaulted) value of the stat 
-		modifierValues[stat] = 1 #The base for modifiers is 1, since it will be multiplied by other modifiers.
+		# Prepare the flat and modifier values that the stat will be set-to and multiplied for.
+		flat_values[stat] = get(stat) #The base value is the current (defaulted) value of the stat 
+		modifier_values[stat] = 1 #The base for modifiers is 1, since it will be multiplied by other modifiers.
 
 		for boost: Boost in active_boosts:
-			#Store the bonuses of the boost added to the flat amount, as well as the modifiers
-			flatValues[stat] += boost.get_stat_boost(stat)
-			modifierValues[stat] *= boost.get_stat_boost_modifier(stat)
+			# Store the bonuses of the boost added to the flat amount, as well as the modifiers
+			flat_values[stat] += boost.get_stat_boost(stat)
+			modifier_values[stat] *= boost.get_stat_boost_modifier(stat)
 		
-		#Set the stat to the flat value multiplied by the modifier
-		set(stat, flatValues[stat] * modifierValues[stat])
+		# Set the stat to the flat value multiplied by the modifier
+		set(stat, flat_values[stat] * modifier_values[stat])
 
 	if Global.debug_mode:
-		var debugLog: String = "Boosts applied with these results: \n"
+		var debug_log: String = "Boosts applied with these results: \n"
 
-		for statName: String in StatListPermanent + StatListCounter:
-			debugLog += "{0}: {1} | Flat boost: {2} | Modifier boost: {3} \n".format(
+		for stat_name: String in StatListPermanent + StatListCounter:
+			debug_log += "{0}: {1} | Flat boost: {2} | Modifier boost: {3} \n".format(
 				[
-					statName,
-					get(statName),
-					flatValues.get(statName, 0 as int),
-					modifierValues.get(statName, 0.0 as float)
+					stat_name,
+					get(stat_name),
+					flat_values.get(stat_name, 0 as int),
+					modifier_values.get(stat_name, 0.0 as float)
 				]
 			)
-		GodotLogger.info(debugLog)
+		GodotLogger.info(debug_log)
 
 
 ## Attempts to get a reference to a [Boost] with the given identifier, if it exists.
@@ -495,17 +495,17 @@ func get_boost_with_identifier(identifier: String) -> Boost:
 
 func to_json(full: bool = false) -> Dictionary:
 	var data: Dictionary = {}
-	for statName in StatListCounter:
-		data[statName] = get(statName)
+	for stat_name in StatListCounter:
+		data[stat_name] = get(stat_name)
 
 	if data.size() != StatListCounter.size():
 		GodotLogger.error("Discrepancy in the amount of stats, StatListCounter may be at fault.")
 
 	if full:
 		var dictForMerge: Dictionary = {}
-		#Fill the dict with the permanent stats
-		for statName in StatListPermanent:
-			dictForMerge[statName] = get(statName)
+		# Fill the dict with the permanent stats
+		for stat_name in StatListPermanent:
+			dictForMerge[stat_name] = get(stat_name)
 
 		data.merge(dictForMerge)
 
@@ -518,27 +518,27 @@ func to_json(full: bool = false) -> Dictionary:
 
 
 func from_json(data: Dictionary, full: bool = false) -> bool:
-	#Validation
-	for statName in StatListCounter:
-		if not statName in data:
-			GodotLogger.warn('Failed to load stats from data, missing "%s" key' % statName)
+	# Validation
+	for stat_name in StatListCounter:
+		if not stat_name in data:
+			GodotLogger.warn('Failed to load stats from data, missing "%s" key' % stat_name)
 			return false
 
 	if full:
-		for statName in StatListPermanent:
-			if not statName in data:
-				GodotLogger.warn('Failed to load stats from data, missing "%s" key' % statName)
+		for stat_name in StatListPermanent:
+			if not stat_name in data:
+				GodotLogger.warn('Failed to load stats from data, missing "%s" key' % stat_name)
 				return false
 
-	#Actually load the data
-	for statName in StatListCounter:
-		self.set(statName, data.get(statName))
+	# Actually load the data
+	for stat_name in StatListCounter:
+		self.set(stat_name, data.get(stat_name))
 
 	experience_needed = calculate_experience_needed(level)
 
 	if full:
-		for statName in StatListPermanent:
-			self.set(statName, data.get(statName))
+		for stat_name in StatListPermanent:
+			self.set(stat_name, data.get(stat_name))
 
 	loaded.emit()
 

--- a/scripts/components/player/charclasscomponent/CharClassSelection.gd
+++ b/scripts/components/player/charclasscomponent/CharClassSelection.gd
@@ -193,6 +193,7 @@ func _on_class_lock_changed():
 func close():
 	if is_inside_tree():
 		get_parent().remove_child(self)
+		JUI.above_ui = false
 
 
 func _on_change_skills_pressed():

--- a/scripts/components/player/charclasscomponent/characterclasscomponent.gd
+++ b/scripts/components/player/charclasscomponent/characterclasscomponent.gd
@@ -203,15 +203,15 @@ func apply_stats():
 
 	var statBoost := Boost.new()
 	statBoost.identifier = "character_classes"
-	
+
 	for charClass: CharacterClassResource in classes:
-		for stat: String in StatsSynchronizerComponent.StatListWithDefaults:			
+		for stat: String in StatsSynchronizerComponent.StatListWithDefaults:
 			#Apply all multipliers and bonuses from classes for the given stat
 			statBoost.add_stat_boost(stat, charClass.get_bonus(stat))
 			statBoost.add_stat_boost_modifier(stat, charClass.get_multiplier(stat), false)
-			
+
 	stats_component.apply_boost(statBoost)
-	
+
 
 func apply_skills():
 	if not G.is_server():

--- a/scripts/components/player/charclasscomponent/characterclasscomponent.gd
+++ b/scripts/components/player/charclasscomponent/characterclasscomponent.gd
@@ -51,8 +51,9 @@ func _ready():
 		add_class("Base")
 
 	#Re-apply stats anytime a class changes.
-	classes_changed.connect(apply_stats)
-	classes_changed.connect(apply_skills)
+	if G.is_server():
+		classes_changed.connect(apply_stats)
+		classes_changed.connect(apply_skills)
 
 	#This line should stay commented until there's a system to detect when a player should be allowed to change classes
 	#class_change_locked = true
@@ -193,32 +194,24 @@ func replace_classes(newClasses: Array[String]):
 			add_class(charclass)
 
 
-## Applies bonuses and multipliers to the character's StatsSynchronizerComponent
+## Applies bonuses and multipliers to the character's StatsSynchronizerComponent as a Boost object
 func apply_stats():
-	#If the stats are not ready, wait another frame.
+	#If the stats are not ready, queue this for the next frame.
 	if not stats_component.ready_done:
 		get_tree().physics_frame.connect(apply_stats)
 		return
 
-	var statsDict: Dictionary = {}
-
-	#Reset character stats before applying the stats from the classes
-	stats_component.load_defaults()
-
-	for stat: String in StatsSynchronizerComponent.StatListWithDefaults:
-		statsDict[stat] = stats_component.get("_default_" + stat)
-
-		#Apply all multipliers from classes for the given stat
-		for charClass: CharacterClassResource in classes:
-			statsDict[stat] *= charClass.get_multiplier(stat)
-
-		#Apply all bonuses from classes
-		for charClass: CharacterClassResource in classes:
-			statsDict[stat] += charClass.get_bonus(stat)
-
-	for statName: String in statsDict:
-		stats_component.set(statName, statsDict[statName])
-
+	var statBoost := Boost.new()
+	statBoost.identifier = "character_classes"
+	
+	for charClass: CharacterClassResource in classes:
+		for stat: String in StatsSynchronizerComponent.StatListWithDefaults:			
+			#Apply all multipliers and bonuses from classes for the given stat
+			statBoost.add_stat_boost(stat, charClass.get_bonus(stat))
+			statBoost.add_stat_boost_modifier(stat, charClass.get_multiplier(stat), false)
+			
+	stats_component.apply_boost(statBoost)
+	
 
 func apply_skills():
 	if not G.is_server():

--- a/scripts/components/player/equipmentsynchronizercomponent/EquipmentSynchronizerComponent.gd
+++ b/scripts/components/player/equipmentsynchronizercomponent/EquipmentSynchronizerComponent.gd
@@ -109,10 +109,13 @@ func get_item(item_uuid: String) -> Item:
 
 func get_boost() -> Boost:
 	var boost: Boost = Boost.new()
+	boost.identifier = "equipment"
+	
 	for equipment_slot in items:
 		var item: Item = items[equipment_slot]
 		if item != null:
-			boost.add_boost(item.boost)
+			boost.combine_boost(item.boost)
+			
 	return boost
 
 

--- a/scripts/components/player/equipmentsynchronizercomponent/EquipmentSynchronizerComponent.gd
+++ b/scripts/components/player/equipmentsynchronizercomponent/EquipmentSynchronizerComponent.gd
@@ -110,12 +110,12 @@ func get_item(item_uuid: String) -> Item:
 func get_boost() -> Boost:
 	var boost: Boost = Boost.new()
 	boost.identifier = "equipment"
-	
+
 	for equipment_slot in items:
 		var item: Item = items[equipment_slot]
 		if item != null:
 			boost.combine_boost(item.boost)
-			
+
 	return boost
 
 


### PR DESCRIPTION
Fixes conflicts between stat changes from classes and equipment  
  
Adds an optional "identifier" property to boosts, if a boost with the same identifier is already present, it overwrites the old one.  
This removes the responsibility of having to remove boosts before adding new ones that are intended to do the same thing.  
For example, the boost coming from all equipment pieces has the "equipment" identifier. So any future Boosts coming from that function will automatically override previously added ones.  
  
This can also work with skills or status effects, a skill can apply a Boost with an identifier "Skill_SkillName" and if it is ever used again on the same target, it will override the Boost provided instead of stacking itself, regardless of who applied it. Or it could be "Skill_SkillName_PlayerName" if it should be tracked per player.
  
It also provides a method to "reload" stored boosts (called automatically when these change) as to get an accurate value out of all the applied ones. Instead of treating boosts like a one-off addition.  
 
From now on, all external, passive modifications to stats, should be done trough boosts.  
If an object needs to constantly modify the boosts it provides, it can keep a reference to the added Boost object and modify that before calling the reload function.   
This means that once a Boost is applied, other objects have no need to keep a reference to the StatsSynchronizerComponent (but still can).