### PR TITLE
Fixing chat

### DIFF
--- a/scenes/player/chatpanel/ChatPanel.gd
+++ b/scenes/player/chatpanel/ChatPanel.gd
@@ -35,8 +35,16 @@ func _ready():
 
 func _input(event):
 	if event.is_action_pressed("ui_accept"):
-		input_field.grab_focus()
-		JUI.chat_active = true
+		if input_field.has_focus():
+			if input_field.text.strip_edges() == "":
+				# Input is empty and enter is pressed, release focus
+				input_field.release_focus()
+				JUI.chat_active = false
+		else:
+			# Input field doesn't have focus, grab it
+			input_field.grab_focus()
+			JUI.chat_active = true
+
 	if event.is_action_pressed("ui_cancel"):
 		input_field.release_focus()
 		# This timer is needed to prevent race conditions with other ui_cancel listeners

--- a/scripts/components/player/playersynchronizer/PlayerSynchronizer.gd
+++ b/scripts/components/player/playersynchronizer/PlayerSynchronizer.gd
@@ -155,7 +155,7 @@ func _physics_process(delta):
 	# Don't do anything when the player is dead
 	if stats_component.is_dead:
 		return
-		
+
 	# Don't do anything if the chat is active
 	if JUI.chat_active:
 		# Stops the player from walking in place

--- a/scripts/components/player/playersynchronizer/PlayerSynchronizer.gd
+++ b/scripts/components/player/playersynchronizer/PlayerSynchronizer.gd
@@ -155,6 +155,12 @@ func _physics_process(delta):
 	# Don't do anything when the player is dead
 	if stats_component.is_dead:
 		return
+		
+	# Don't do anything if the chat is active
+	if JUI.chat_active:
+		# Stops the player from walking in place
+		animation_player.play("Idle")
+		return
 
 	# Server-side logic
 	if G.is_server():


### PR DESCRIPTION
The chat can now also be closed using enter when it is clear from text.
The player now cannot move around when the chat is open.