### PR TITLE
Color coded folders in editor

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -43,6 +43,19 @@ project/assembly_name="Jdungeon"
 
 enabled=PackedStringArray("res://addons/gut/plugin.cfg", "res://addons/logger/plugin.cfg")
 
+[file_customization]
+
+folder_colors={
+"res://addons/": "gray",
+"res://assets/": "yellow",
+"res://data/": "gray",
+"res://docker/": "pink",
+"res://documentation/": "gray",
+"res://scenes/": "blue",
+"res://scripts/": "purple",
+"res://test/": "pink"
+}
+
 [gui]
 
 timers/tooltip_delay_sec=0.05


### PR DESCRIPTION
This feature is rather new but we never used it. It highlights folders and sub-folders with a chosen color. Makes it easier to identify the current folder in the Filesystem tab in the editor, specially when you're deep into sub-folders and unable to see the root one.    
  
Coloring logic:   
- Yellow: imported resources  
- Pink: non-Godot related functionality  
- Blue: scenes  
- Purple: scripts  
- Grey: external data/unrelated to the game's code

  
![image](https://github.com/jonathaneeckhout/jdungeon/assets/55665720/d5aab326-4328-4802-9f23-3e7b069735f6)
