### PR TITLE
Changes game icon to a random enemy and adds a small flair for servers and gateways icons.

### DIFF
--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -86,7 +86,7 @@ func parse_cmd_arguments():
 
 func start_gateway() -> bool:
 	set_game_icon(GAME_ICONS.pick_random(), GATEWAY_SUB_ICON)
-	
+
 	GodotLogger._prefix = "GatewayServer"
 
 	GodotLogger.info("Running as Gateway")
@@ -126,7 +126,7 @@ func start_gateway() -> bool:
 
 func start_server() -> bool:
 	set_game_icon(GAME_ICONS.pick_random(), SERVER_SUB_ICON)
-	
+
 	# Set the prefix for all the logs on this instance
 	GodotLogger._prefix = "GameServer"
 
@@ -218,7 +218,7 @@ func _server_get_map() -> String:
 
 func start_client() -> bool:
 	set_game_icon(GAME_ICONS.pick_random())
-	
+
 	GodotLogger._prefix = "Client"
 
 	GodotLogger.info("Running as client")
@@ -281,21 +281,21 @@ func start_client() -> bool:
 func set_game_icon(icon: Texture, sub_icon: Texture = null):
 	var image: Image = icon.get_image()
 	image.resize(64, 64)
-	
+
 	if sub_icon is Texture:
 		var sub_image: Image = sub_icon.get_image()
 		sub_image.resize(32, 32)
-		
-		var initial_pos := Vector2i(32,32)
-		
+
+		var initial_pos := Vector2i(32, 32)
+
 		for width: int in sub_image.get_width():
 			for height: int in sub_image.get_height():
 				var pixel_pos := Vector2i(width, height)
-				
+
 				#Ignore empty pixels
 				if sub_image.get_pixelv(pixel_pos).a < 0.1:
 					continue
-					
+
 				image.set_pixelv(initial_pos + pixel_pos, sub_image.get_pixelv(pixel_pos))
 
 	DisplayServer.set_icon(image)

--- a/scenes/root/Root.gd
+++ b/scenes/root/Root.gd
@@ -16,6 +16,16 @@ const SERVER_FPS: int = 20
 ## FPS used on the client-side
 const CLIENT_FPS: int = 60
 
+const GAME_ICONS: Array[Texture] = [
+	preload("res://assets/images/enemies/boar/scaled/example.png"),
+	preload("res://assets/images/enemies/flower/scaled/Flower.png"),
+	preload("res://assets/images/enemies/moldeddruvar/scaled/moldeddruvar.png"),
+	preload("res://assets/images/enemies/sheep/scaled/sheep.png"),
+]
+
+const SERVER_SUB_ICON: Texture = preload("res://assets/images/ui/cursors/LootCursor.png")
+const GATEWAY_SUB_ICON: Texture = preload("res://assets/images/ui/cursors/TalkCursor.png")
+
 @onready var ui: CanvasLayer = $UI
 @onready var select_run_mode: Control = $UI/SelectRunMode
 @onready var select_mode_buttons: VBoxContainer = $UI/SelectRunMode/SelectModeButtons
@@ -75,6 +85,8 @@ func parse_cmd_arguments():
 
 
 func start_gateway() -> bool:
+	set_game_icon(GAME_ICONS.pick_random(), GATEWAY_SUB_ICON)
+	
 	GodotLogger._prefix = "GatewayServer"
 
 	GodotLogger.info("Running as Gateway")
@@ -113,6 +125,8 @@ func start_gateway() -> bool:
 
 
 func start_server() -> bool:
+	set_game_icon(GAME_ICONS.pick_random(), SERVER_SUB_ICON)
+	
 	# Set the prefix for all the logs on this instance
 	GodotLogger._prefix = "GameServer"
 
@@ -203,6 +217,8 @@ func _server_get_map() -> String:
 
 
 func start_client() -> bool:
+	set_game_icon(GAME_ICONS.pick_random())
+	
 	GodotLogger._prefix = "Client"
 
 	GodotLogger.info("Running as client")
@@ -260,6 +276,29 @@ func start_client() -> bool:
 	GodotLogger.info("Client successfully started")
 	get_window().title = "JDungeon (Client)"
 	return true
+
+
+func set_game_icon(icon: Texture, sub_icon: Texture = null):
+	var image: Image = icon.get_image()
+	image.resize(64, 64)
+	
+	if sub_icon is Texture:
+		var sub_image: Image = sub_icon.get_image()
+		sub_image.resize(32, 32)
+		
+		var initial_pos := Vector2i(32,32)
+		
+		for width: int in sub_image.get_width():
+			for height: int in sub_image.get_height():
+				var pixel_pos := Vector2i(width, height)
+				
+				#Ignore empty pixels
+				if sub_image.get_pixelv(pixel_pos).a < 0.1:
+					continue
+					
+				image.set_pixelv(initial_pos + pixel_pos, sub_image.get_pixelv(pixel_pos))
+
+	DisplayServer.set_icon(image)
 
 
 func _on_run_as_gateway_pressed():


### PR DESCRIPTION
The Root node now assigns a randomized icon to an instance once one of the 3 modes is selected.      
It also adds a small mini-icon (not random) on top of the main one if the instance is a gateway or a server.
  
Icons are resized to 64x64 and sub-icons to 32x32 (because i am 60% sure it will break on some OS by using arbitrary sizes)  

**Example:**  
![image](https://github.com/jonathaneeckhout/jdungeon/assets/55665720/9e7635d7-2e03-49b4-8ceb-e0de6f071300)
    
To test simply launch an instance and select a mode.  
  
Closes: #214 
