### PR TITLE
Fix memory leak

### DIFF
--- a/scripts/classes/Boost.gd
+++ b/scripts/classes/Boost.gd
@@ -1,4 +1,4 @@
-extends Object
+extends RefCounted
 class_name Boost
 ## This is used to store the boosts a player may obtain. Most common sources being items and status effects.
 ## These are meant to be temporary and may be deleted at any time.

--- a/scripts/components/player/skillcomponent/SkillUseInfo.gd
+++ b/scripts/components/player/skillcomponent/SkillUseInfo.gd
@@ -1,4 +1,4 @@
-extends Object
+extends RefCounted
 
 class_name SkillUseInfo
 


### PR DESCRIPTION
Changed Boost and SkillUseInfo to be RefCounted.  
  
The Monitor was showing a steady increase in Objects in memory, not anymore. It's still kinda problematic that these many objects are being created, but it's likely an optimization issue (and the leak was probably always present, just ticking up too slowly to be noticed)  

Reminder to self: Do not use "Object" for disposable stuff.  
  
Closes: #228 