### PR TITLE
Fixes projectiles not hitting enemy HurtBox Area2D

### DIFF
--- a/scripts/components/networking/projectilesynchronizercomponent/Projectile2D.gd
+++ b/scripts/components/networking/projectilesynchronizercomponent/Projectile2D.gd
@@ -61,6 +61,7 @@ func process_collisions(motion: Vector2):
 	var space_state: PhysicsDirectSpaceState2D = get_world_2d().direct_space_state
 	var shape_params := PhysicsShapeQueryParameters2D.new()
 
+	shape_params.collide_with_areas = true
 	shape_params.collision_mask = collision_mask
 	shape_params.motion = current_motion
 	shape_params.shape = $CollisionShape2D.shape

--- a/scripts/components/networking/projectilesynchronizercomponent/Projectiles/Arrow.tscn
+++ b/scripts/components/networking/projectilesynchronizercomponent/Projectiles/Arrow.tscn
@@ -5,18 +5,18 @@
 [ext_resource type="PackedScene" uid="uid://cloh3hx8jfl61" path="res://scenes/projectiles/collision_scenes/Puff.tscn" id="2_mvj3j"]
 
 [sub_resource type="SegmentShape2D" id="SegmentShape2D_l0reg"]
-a = Vector2(-10, 0)
-b = Vector2(55, 0)
+b = Vector2(26, 0)
 
 [node name="Arrow" type="StaticBody2D"]
 script = ExtResource("1_hrrne")
 projectile_class = "Arrow"
 skill_class = "BasicAttack"
 collision_scene = ExtResource("2_mvj3j")
-move_speed = 400.0
+move_speed = 850.0
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 rotation = 1.5708
+scale = Vector2(0.5, 0.5)
 texture = ExtResource("2_1i1lo")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/scripts/components/networking/projectilesynchronizercomponent/projectilesynchronizercomponent.gd
+++ b/scripts/components/networking/projectilesynchronizercomponent/projectilesynchronizercomponent.gd
@@ -203,11 +203,19 @@ func show_collision(global_pos: Vector2, projectile_class: String):
 
 
 func _on_projectile_hit_object(object: Node2D, projectile: Projectile2D):
+	var obj_hit: Node2D = object
+	
+	#If it touched a HurtBox, get the entity that owns it.
+	if obj_hit.get_name() == "HurtArea":
+		obj_hit = obj_hit.get_parent()  
+		assert(obj_hit is CharacterBody2D)
+	
 	# Try to get an entity with the object's name, as to confirm it is one.
-	var hit_entity: Node2D = G.world.get_entity_by_name(object.get_name())
-
+	var hit_entity: Node2D = G.world.get_entity_by_name(obj_hit.get_name())
+	
+	#If no entity was found, just report the object hit
 	if hit_entity == null:
-		projectile_hit_object.emit(object)
+		projectile_hit_object.emit(obj_hit)
 		return
 
 	# If the projectile has a skill defined, use it.
@@ -227,7 +235,7 @@ func _on_projectile_hit_object(object: Node2D, projectile: Projectile2D):
 	for client_id: int in get_clients_in_range():
 		sync_collision_to_client(client_id, projectile.position, projectile.projectile_class)
 
-	projectile_hit_object.emit(object)
+	projectile_hit_object.emit(obj_hit)
 	projectile_hit_entity.emit(hit_entity)
 
 

--- a/scripts/components/networking/projectilesynchronizercomponent/projectilesynchronizercomponent.gd
+++ b/scripts/components/networking/projectilesynchronizercomponent/projectilesynchronizercomponent.gd
@@ -204,15 +204,17 @@ func show_collision(global_pos: Vector2, projectile_class: String):
 
 func _on_projectile_hit_object(object: Node2D, projectile: Projectile2D):
 	var obj_hit: Node2D = object
-	
+
 	#If it touched a HurtBox, get the entity that owns it.
-	if obj_hit.get_name() == "HurtArea":
-		obj_hit = obj_hit.get_parent()  
-		assert(obj_hit is CharacterBody2D)
-	
-	# Try to get an entity with the object's name, as to confirm it is one.
-	var hit_entity: Node2D = G.world.get_entity_by_name(obj_hit.get_name())
-	
+	if obj_hit.get_name() == "HurtArea" and get_parent():
+		obj_hit = obj_hit.get_parent()
+
+	var hit_entity: Node2D = null
+
+	# Try to get an entity with the object's name if it is a CharacterBody2D, as to confirm it is one.
+	if obj_hit is CharacterBody2D:
+		hit_entity = G.world.get_entity_by_name(obj_hit.get_name())
+
 	#If no entity was found, just report the object hit
 	if hit_entity == null:
 		projectile_hit_object.emit(obj_hit)


### PR DESCRIPTION
Projectiles now collide with Area2Ds, if the Area2D is called "HurtBox" (like the enemy's), the projectile will try to fetch the owner of it and hit that instead (a bit of a dirty hack, but it's the best i can do without a dedicated system for "damage detection").  
  
TODO:
- [x] Make arrows smaller and fly faster  
  
Closes: #226 