### PR TITLE
Item stacking (again)

### DIFF
--- a/classes/Item.gd
+++ b/classes/Item.gd
@@ -2,7 +2,7 @@ extends StaticBody2D
 
 class_name Item
 
-signal amount_changed(this: Item, new_amount: int)
+signal amount_changed(new_amount: int)
 
 enum MODE { LOOT, ITEMSLOT }
 
@@ -30,8 +30,8 @@ var amount_max: int = 1
 var amount: int = 1:
 	set(val):
 		amount = val
+		amount_changed.emit(amount)
 
-		amount_changed.emit(self, amount)
 var price: int = 0
 var value: int = 0
 
@@ -100,10 +100,17 @@ func server_use(player: Player) -> bool:
 		ITEM_TYPE.CONSUMABLE:
 			if boost.hp > 0:
 				player.stats.heal(self.name, boost.hp)
+
+				if amount <= 1:
+					player.inventory.remove_item(uuid)
+				else:
+					player.inventory.set_item_amount(uuid, amount - 1)
 				return true
+
 		ITEM_TYPE.EQUIPMENT:
 			if player.equipment and player.equipment.server_equip_item(self):
 				return true
+
 			else:
 				GodotLogger.info("%s could not equip item %s" % [player.name, item_class])
 				return false

--- a/classes/Item.gd
+++ b/classes/Item.gd
@@ -102,13 +102,14 @@ func server_use(player: Player) -> bool:
 				player.stats.heal(self.name, boost.hp)
 
 				if amount <= 1:
-					player.inventory.remove_item(uuid)
+					player.inventory.server_remove_item(uuid)
 				else:
-					player.inventory.set_item_amount(uuid, amount - 1)
+					player.inventory.server_change_item_amount(uuid, amount - 1)
 				return true
 
 		ITEM_TYPE.EQUIPMENT:
 			if player.equipment and player.equipment.server_equip_item(self):
+				player.inventory.server_remove_item(uuid)
 				return true
 
 			else:

--- a/classes/Item.gd
+++ b/classes/Item.gd
@@ -104,7 +104,7 @@ func server_use(player: Player) -> bool:
 				if amount <= 1:
 					player.inventory.server_remove_item(uuid)
 				else:
-					player.inventory.server_change_item_amount(uuid, amount - 1)
+					player.inventory.server_set_item_amount(uuid, amount - 1)
 				return true
 
 		ITEM_TYPE.EQUIPMENT:

--- a/classes/Item.gd
+++ b/classes/Item.gd
@@ -2,6 +2,8 @@ extends StaticBody2D
 
 class_name Item
 
+signal amount_changed(this: Item, new_amount: int)
+
 enum MODE { LOOT, ITEMSLOT }
 
 enum ITEM_TYPE { EQUIPMENT, CONSUMABLE, CURRENCY }
@@ -24,7 +26,12 @@ var expire_timer: Timer
 
 var drop_rate: float = 0.0
 
-var amount: int = 1
+var amount_max: int = 1
+var amount: int = 1:
+	set(val):
+		amount = val
+
+		amount_changed.emit(self, amount)
 var price: int = 0
 var value: int = 0
 
@@ -64,6 +71,10 @@ func _ready():
 		expire_timer.wait_time = expire_time
 		expire_timer.timeout.connect(_on_expire_timer_timeout)
 		add_child(expire_timer)
+
+
+func get_icon() -> Texture:
+	return $Icon.texture
 
 
 func start_expire_timer():
@@ -113,6 +124,12 @@ func from_json(data: Dictionary) -> bool:
 	amount = data["amount"]
 
 	return true
+
+
+static func instance_from_json(data: Dictionary) -> Item:
+	var new_item := Item.new()
+	new_item.from_json(data)
+	return new_item
 
 
 func _on_expire_timer_timeout():

--- a/components/connection/PlayerSpawnSynchronizer/PlayerSpawnSynchronizer.gd
+++ b/components/connection/PlayerSpawnSynchronizer/PlayerSpawnSynchronizer.gd
@@ -35,7 +35,9 @@ func _ready():
 		user_authenticator.server_player_logged_in.connect(_on_server_player_logged_in)
 
 		# Connect to the disconnect signal, this is the trigger to emit the signal to remove the player from the server instance
-		_multiplayer_connection.multiplayer_api.peer_disconnected.connect(_on_server_peer_disconnected)
+		_multiplayer_connection.multiplayer_api.peer_disconnected.connect(
+			_on_server_peer_disconnected
+		)
 	else:
 		pass
 

--- a/components/player/equipmentsynchronizercomponent/EquipmentSynchronizerComponent.gd
+++ b/components/player/equipmentsynchronizercomponent/EquipmentSynchronizerComponent.gd
@@ -14,7 +14,7 @@ var _target_node: Node
 
 var _equipment_synchronizer_rpc: EquipmentSynchronizerRPC = null
 
-var items = {
+var items: Dictionary = {
 	"Head": null,
 	"Body": null,
 	"Legs": null,
@@ -144,7 +144,7 @@ func _unequip_item(item_uuid: String) -> Item:
 
 
 func get_item(item_uuid: String) -> Item:
-	for equipment_slot in items:
+	for equipment_slot: String in items:
 		var item: Item = items[equipment_slot]
 		if item != null and item.uuid == item_uuid:
 			return item
@@ -156,7 +156,7 @@ func get_boost() -> Boost:
 	var boost: Boost = Boost.new()
 	boost.identifier = "equipment"
 
-	for equipment_slot in items:
+	for equipment_slot: String in items:
 		var item: Item = items[equipment_slot]
 		if item != null:
 			boost.combine_boost(item.boost)
@@ -167,7 +167,7 @@ func get_boost() -> Boost:
 func to_json() -> Dictionary:
 	var output: Dictionary = {}
 
-	for slot in items:
+	for slot: String in items:
 		if items[slot] != null:
 			var item: Item = items[slot]
 			output[slot] = item.to_json()
@@ -176,7 +176,7 @@ func to_json() -> Dictionary:
 
 
 func from_json(data: Dictionary) -> bool:
-	for slot in data:
+	for slot: String in data:
 		if not slot in items:
 			GodotLogger.warn("Slot=[%s] does not exist in equipment items" % slot)
 			return false

--- a/components/player/inventorysynchronizercomponent/InventorySynchronizerComponent.gd
+++ b/components/player/inventorysynchronizercomponent/InventorySynchronizerComponent.gd
@@ -5,6 +5,7 @@ class_name InventorySynchronizerComponent
 signal loaded
 signal item_added(item_uuid: String, item_class: String)
 signal item_removed(item_uuid: String)
+signal item_amount_changed(item_uuid: String)
 
 signal gold_added(total: int, amount: int)
 signal gold_removed(total: int, amount: int)
@@ -65,26 +66,53 @@ func server_sync_inventory(peer_id: int):
 	_inventory_synchronizer_rpc.sync_response(peer_id, to_json())
 
 
+## Attempts to stack items or add them if there's nowhere else to stack them. Stacking is purely server sided.
 func server_add_item(item: Item) -> bool:
 	if not _target_node.multiplayer_connection.is_server():
 		return false
 
+	#Currency is directly added to gold
 	if item.item_type == Item.ITEM_TYPE.CURRENCY:
 		server_add_gold(item.amount)
 		return true
 
 	item.collision_layer = 0
-
+	
+	#Inventory full
 	if items.size() >= size:
 		return false
+	
+	#Try to stack
+	var existing_item: Item = get_item_by_class(item.item_class)
+	if existing_item is Item and existing_item.amount < existing_item.amount_max:
+		var remaining_space: int = existing_item.amount_max - existing_item.amount
+		var amount_to_add: int = min(item.amount, remaining_space)
+		
+		#If there's space remaining, add some of this item's to the stack.
+		#This is delegated to the server_change_item_amount() function which synchronizes amounts by itself.
+		if remaining_space > 0:	
+			server_change_item_amount(existing_item.uuid, existing_item.amount + amount_to_add)
+			
+		server_change_item_amount(item.uuid, item.amount - amount_to_add)
+		
+		#Any remaining amount is added as a separate item
+		if item.amount > 0:
+			server_add_item(item)
+			_inventory_synchronizer_rpc.add_item(
+				_target_node.peer_id, item.name, item.item_class, item.amount
+			)
+		
+		return true
+	
+	#Adding the item from scratch
+	else:
+		items.append(item)
+		
+		_inventory_synchronizer_rpc.add_item(
+			_target_node.peer_id, item.name, item.item_class, item.amount
+		)
 
-	items.append(item)
-
-	_inventory_synchronizer_rpc.add_item(
-		_target_node.peer_id, item.name, item.item_class, item.amount
-	)
-
-	return true
+		return true
 
 
 func client_add_item(item_uuid: String, item_class: String, amount: int):
@@ -118,11 +146,39 @@ func client_remove_item(item_uuid: String):
 		item_removed.emit(item_uuid)
 
 
+func server_change_item_amount(item_uuid: String, amount: int):
+	if not _target_node.multiplayer_connection.is_server():
+		return false
+	
+	var item: Item = get_item(item_uuid)
+	if item != null:
+		item.amount = amount
+		_inventory_synchronizer_rpc.change_item_amount(_target_node.peer_id, item_uuid, amount)
+
+
+func client_change_item_amount(item_uuid: String, amount: int):
+	var item: Item = get_item(item_uuid)
+	if item != null:
+		item.amount = amount
+
+		item_amount_changed.emit(item_uuid)
+
+
 func get_item(item_uuid: String) -> Item:
 	for item in items:
 		if item.uuid == item_uuid:
 			return item
 
+	return null
+
+
+## Returns the first instance of an item of this class
+func get_item_by_class(item_class: String) -> Item:
+	for item: Item in items:
+		if item.item_class == item_class:
+			return item
+
+	GodotLogger.warn("Could not find item of class '{0}'.".format([item_class]))
 	return null
 
 

--- a/components/player/inventorysynchronizercomponent/InventorySynchronizerComponent.gd
+++ b/components/player/inventorysynchronizercomponent/InventorySynchronizerComponent.gd
@@ -188,7 +188,6 @@ func server_use_item(item_uuid: String):
 
 	var item: Item = get_item(item_uuid)
 	if item and item.server_use(_target_node):
-		server_remove_item(item_uuid)
 		return true
 
 	return false

--- a/components/player/inventorysynchronizercomponent/InventorySynchronizerRPC.gd
+++ b/components/player/inventorysynchronizercomponent/InventorySynchronizerRPC.gd
@@ -38,6 +38,10 @@ func remove_item(peer_id: int, item_uuid: String):
 	_remove_item.rpc_id(peer_id, item_uuid)
 
 
+func change_item_amount(peer_id: int, item_uuid: String, amount: int):
+	_change_item_amount.rpc_id(peer_id, item_uuid, amount)
+
+
 func add_gold(peer_id: int, total: int, amount: int):
 	_add_gold.rpc_id(peer_id, total, amount)
 
@@ -125,6 +129,22 @@ func _remove_item(u: String):
 			. client_player
 			. component_list[InventorySynchronizerComponent.COMPONENT_NAME]
 			. client_remove_item(u)
+		)
+
+
+@rpc("call_remote", "authority", "reliable")
+func _change_item_amount(u: String, a: int):
+	if _multiplayer_connection.client_player == null:
+		return
+
+	if _multiplayer_connection.client_player.component_list.has(
+		InventorySynchronizerComponent.COMPONENT_NAME
+	):
+		(
+			_multiplayer_connection
+			. client_player
+			. component_list[InventorySynchronizerComponent.COMPONENT_NAME]
+			. client_change_item_amount(u, a)
 		)
 
 

--- a/scenes/items/consumables/healthpotion/HealthPotion.gd
+++ b/scenes/items/consumables/healthpotion/HealthPotion.gd
@@ -7,3 +7,4 @@ func _init():
 	item_class = "HealthPotion"
 	item_type = ITEM_TYPE.CONSUMABLE
 	boost.hp = 25
+	amount_max = 6

--- a/scenes/player/inventory/Inventory.gd
+++ b/scenes/player/inventory/Inventory.gd
@@ -62,7 +62,6 @@ func register_signals():
 
 	inventory_synchronizer.item_added.connect(_on_item_added)
 	inventory_synchronizer.item_removed.connect(_on_item_removed)
-	inventory_synchronizer.inventory_redraw_required.connect(_on_redraw_required)
 
 
 func get_panel_at_pos(pos: Vector2) -> InventoryPanel:

--- a/scenes/player/inventory/Inventory.gd
+++ b/scenes/player/inventory/Inventory.gd
@@ -51,7 +51,7 @@ func _input(event):
 			hide()
 		else:
 			update_inventory()
-			player.inventory.sync_inventory.rpc_id(1)
+			inventory_synchronizer.sync_invendtory.rpc_id(1)
 			show()
 
 
@@ -113,7 +113,7 @@ func update_inventory():
 	panels_with_invalid_items = panel_item_uuid_dictionary.duplicate()
 
 	#Check every inventory item
-	for inv_item: Item in player.inventory.items:
+	for inv_item: Item in inventory_synchronizer.items:
 		#Unmark as invalid those who have been found in the inventory
 		panels_with_invalid_items.erase(inv_item.uuid)
 

--- a/scenes/player/inventory/Inventory.gd
+++ b/scenes/player/inventory/Inventory.gd
@@ -51,7 +51,6 @@ func _input(event):
 			hide()
 		else:
 			update_inventory()
-			inventory_synchronizer.sync_invendtory.rpc_id(1)
 			show()
 
 

--- a/scenes/player/inventory/Inventory.gd
+++ b/scenes/player/inventory/Inventory.gd
@@ -72,8 +72,8 @@ func get_panel_at_pos(pos: Vector2) -> InventoryPanel:
 
 func get_panels(occupied_only: bool) -> Array[InventoryPanel]:
 	var output: Array[InventoryPanel] = []
-	var temp_arr: Array = []		
-	
+	var temp_arr: Array = []
+
 	if occupied_only:
 		for row: Array in panels:
 			for panel: InventoryPanel in row:
@@ -82,7 +82,7 @@ func get_panels(occupied_only: bool) -> Array[InventoryPanel]:
 	else:
 		for row: Array in panels:
 			temp_arr += row
-	
+
 	output.assign(temp_arr)
 	return output
 
@@ -98,41 +98,39 @@ func update_inventory():
 	var occupied_panels: Array[InventoryPanel] = get_panels(true)
 	var panel_item_uuid_dictionary: Dictionary = {}
 	var panels_with_invalid_items: Dictionary = {}
-	
+
 	#Ensure all panels have an item
 	assert(
-		occupied_panels.all( 
-			func(panel_occupied: InventoryPanel):
-				return panel_occupied.item is Item
-				)
+		occupied_panels.all(
+			func(panel_occupied: InventoryPanel): return panel_occupied.item is Item
 		)
-	
+	)
+
 	#Store the uuid of the item that each panel has to accelerate the rest of the update.
 	for panel: InventoryPanel in occupied_panels:
 		panel_item_uuid_dictionary[panel.item.uuid] = panel
-	
+
 	#All panels are assumed invalid until proven otherwise.
 	panels_with_invalid_items = panel_item_uuid_dictionary.duplicate()
-		
+
 	#Check every inventory item
 	for inv_item: Item in player.inventory.items:
-		
 		#Unmark as invalid those who have been found in the inventory
 		panels_with_invalid_items.erase(inv_item.uuid)
-		
+
 		#No item with this uuid has been found in the displayed inventory, add it.
 		if not inv_item.uuid in panel_item_uuid_dictionary.keys():
 			place_item_at_free_slot(inv_item)
-		
+
 		else:
 			#Item found, update it.
 			panel_item_uuid_dictionary[inv_item.uuid].item = inv_item
 			panel_item_uuid_dictionary[inv_item.uuid].queue_redraw()
-			
+
 	#Clear any panels with items that are NOT in the inventory
 	for item_uuid: String in panels_with_invalid_items:
 		panels_with_invalid_items[item_uuid].item = null
-		
+
 
 func place_item_at_free_slot(item: Item) -> bool:
 	for y in range(SIZE.y):

--- a/scenes/player/inventory/Inventory.gd
+++ b/scenes/player/inventory/Inventory.gd
@@ -50,6 +50,8 @@ func _input(event):
 		if visible:
 			hide()
 		else:
+			update_inventory()
+			player.inventory.sync_inventory.rpc_id(1)
 			show()
 
 
@@ -68,12 +70,69 @@ func get_panel_at_pos(pos: Vector2) -> InventoryPanel:
 	return $GridContainer.get_node(panel_path)
 
 
+func get_panels(occupied_only: bool) -> Array[InventoryPanel]:
+	var output: Array[InventoryPanel] = []
+	var temp_arr: Array = []		
+	
+	if occupied_only:
+		for row: Array in panels:
+			for panel: InventoryPanel in row:
+				if panel.item is Item:
+					temp_arr.append(panel)
+	else:
+		for row: Array in panels:
+			temp_arr += row
+	
+	output.assign(temp_arr)
+	return output
+
+
 func swap_items(from: Panel, to: Panel):
 	var temp_item: Item = to.item
 
 	to.item = from.item
 	from.item = temp_item
 
+
+func update_inventory():
+	var occupied_panels: Array[InventoryPanel] = get_panels(true)
+	var panel_item_uuid_dictionary: Dictionary = {}
+	var panels_with_invalid_items: Dictionary = {}
+	
+	#Ensure all panels have an item
+	assert(
+		occupied_panels.all( 
+			func(panel_occupied: InventoryPanel):
+				return panel_occupied.item is Item
+				)
+		)
+	
+	#Store the uuid of the item that each panel has to accelerate the rest of the update.
+	for panel: InventoryPanel in occupied_panels:
+		panel_item_uuid_dictionary[panel.item.uuid] = panel
+	
+	#All panels are assumed invalid until proven otherwise.
+	panels_with_invalid_items = panel_item_uuid_dictionary.duplicate()
+		
+	#Check every inventory item
+	for inv_item: Item in player.inventory.items:
+		
+		#Unmark as invalid those who have been found in the inventory
+		panels_with_invalid_items.erase(inv_item.uuid)
+		
+		#No item with this uuid has been found in the displayed inventory, add it.
+		if not inv_item.uuid in panel_item_uuid_dictionary.keys():
+			place_item_at_free_slot(inv_item)
+		
+		else:
+			#Item found, update it.
+			panel_item_uuid_dictionary[inv_item.uuid].item = inv_item
+			panel_item_uuid_dictionary[inv_item.uuid].queue_redraw()
+			
+	#Clear any panels with items that are NOT in the inventory
+	for item_uuid: String in panels_with_invalid_items:
+		panels_with_invalid_items[item_uuid].item = null
+		
 
 func place_item_at_free_slot(item: Item) -> bool:
 	for y in range(SIZE.y):
@@ -82,6 +141,7 @@ func place_item_at_free_slot(item: Item) -> bool:
 			var panel: InventoryPanel = get_panel_at_pos(pos)
 			if panel.item == null:
 				panel.item = item
+				panel.queue_redraw()
 				return true
 	return false
 

--- a/scenes/player/inventory/Inventory.gd
+++ b/scenes/player/inventory/Inventory.gd
@@ -12,7 +12,7 @@ var gold := 0:
 		gold = amount
 		$VBoxContainer/GoldValue.text = str(amount)
 
-var panels = []
+var panels: Array[Array] = []
 var mouse_above_this_panel: InventoryPanel
 var location_cache = {}
 
@@ -60,6 +60,7 @@ func register_signals():
 
 	inventory_synchronizer.item_added.connect(_on_item_added)
 	inventory_synchronizer.item_removed.connect(_on_item_removed)
+	inventory_synchronizer.inventory_redraw_required.connect(_on_redraw_required)
 
 
 func get_panel_at_pos(pos: Vector2) -> InventoryPanel:
@@ -133,3 +134,9 @@ func _on_item_removed(item_uuid: String):
 			if panel.item and panel.item.uuid == item_uuid:
 				panel.item = null
 				return
+
+
+func _on_redraw_required():
+	for row: Array in panels:
+		for panel: InventoryPanel in row:
+			panel.queue_redraw()

--- a/scenes/player/inventory/InventoryPanel.gd
+++ b/scenes/player/inventory/InventoryPanel.gd
@@ -6,11 +6,20 @@ const DEFAULT_FONT: Font = preload("res://addons/gut/fonts/LobsterTwo-Regular.tt
 
 @export var item: Item:
 	set(new_item):
+		if item is Item and item.amount_changed.is_connected(on_item_amount_changed):
+				item.amount_changed.disconnect(on_item_amount_changed)
+				
 		item = new_item
-		if item:
+		
+		if item is Item:
+			if not item.amount_changed.is_connected(on_item_amount_changed):
+				item.amount_changed.connect(on_item_amount_changed)		
 			$TextureRect.texture = item.get_node("Icon").texture
 		else:
+			
 			$TextureRect.texture = null
+			
+		queue_redraw()
 
 @onready var inventory: Inventory = $"../.."
 @onready var drag_panel = $"../../DragPanel"
@@ -42,6 +51,9 @@ func _ready():
 	mouse_entered.connect(_on_mouse_entered)
 	mouse_exited.connect(_on_mouse_exited)
 
+
+
+	
 
 func _draw():
 	if item is Item:
@@ -86,3 +98,7 @@ func _on_mouse_entered():
 
 func _on_mouse_exited():
 	inventory.mouse_above_this_panel = null
+
+
+func on_item_amount_changed(item: Item, amount: int):
+	queue_redraw()

--- a/scenes/player/inventory/InventoryPanel.gd
+++ b/scenes/player/inventory/InventoryPanel.gd
@@ -7,18 +7,17 @@ const DEFAULT_FONT: Font = preload("res://addons/gut/fonts/LobsterTwo-Regular.tt
 @export var item: Item:
 	set(new_item):
 		if item is Item and item.amount_changed.is_connected(on_item_amount_changed):
-				item.amount_changed.disconnect(on_item_amount_changed)
-				
+			item.amount_changed.disconnect(on_item_amount_changed)
+
 		item = new_item
-		
+
 		if item is Item:
 			if not item.amount_changed.is_connected(on_item_amount_changed):
-				item.amount_changed.connect(on_item_amount_changed)		
+				item.amount_changed.connect(on_item_amount_changed)
 			$TextureRect.texture = item.get_node("Icon").texture
 		else:
-			
 			$TextureRect.texture = null
-			
+
 		queue_redraw()
 
 @onready var inventory: Inventory = $"../.."
@@ -52,14 +51,18 @@ func _ready():
 	mouse_exited.connect(_on_mouse_exited)
 
 
-
-	
-
 func _draw():
-	if item is Item:
+	if item is Item and item.amount != 1:
 		var font_height: int = 14
-		draw_string(DEFAULT_FONT, Vector2(0, size.y - font_height), str(item.amount),HORIZONTAL_ALIGNMENT_CENTER, -1, font_height)
-		
+		draw_string(
+			DEFAULT_FONT,
+			Vector2(0, size.y - font_height),
+			str(item.amount),
+			HORIZONTAL_ALIGNMENT_CENTER,
+			-1,
+			font_height
+		)
+
 
 func _gui_input(event: InputEvent):
 	if event.is_action_pressed("j_left_click"):
@@ -87,7 +90,7 @@ func _gui_input(event: InputEvent):
 			drag_panel.hide()
 
 
-func _physics_process(_delta):
+func _physics_process(_delta: float):
 	if selected:
 		drag_panel.position = get_local_mouse_position() + drag_panel_offset
 
@@ -100,5 +103,5 @@ func _on_mouse_exited():
 	inventory.mouse_above_this_panel = null
 
 
-func on_item_amount_changed(item: Item, amount: int):
+func on_item_amount_changed(_amount: int):
 	queue_redraw()

--- a/scenes/player/inventory/InventoryPanel.gd
+++ b/scenes/player/inventory/InventoryPanel.gd
@@ -2,6 +2,8 @@ extends Panel
 
 class_name InventoryPanel
 
+const DEFAULT_FONT: Font = preload("res://addons/gut/fonts/LobsterTwo-Regular.ttf")
+
 @export var item: Item:
 	set(new_item):
 		item = new_item
@@ -40,6 +42,12 @@ func _ready():
 	mouse_entered.connect(_on_mouse_entered)
 	mouse_exited.connect(_on_mouse_exited)
 
+
+func _draw():
+	if item is Item:
+		var font_height: int = 14
+		draw_string(DEFAULT_FONT, Vector2(0, size.y - font_height), str(item.amount),HORIZONTAL_ALIGNMENT_CENTER, -1, font_height)
+		
 
 func _gui_input(event: InputEvent):
 	if event.is_action_pressed("j_left_click"):


### PR DESCRIPTION
When an item is added, it will attempt to stack it onto another item whose amount does not match or exceed Item.amount_max.    
  
Refactored Item.use() and related functions to no longer forcibly remove used items, now it depends on the item being used and the amount remaining.  
Consumables remove a single unit from their stack on use (and get fully removed when the last one is used).  
Equipment is removed from the inventory directly, but their amount does not change (this allows for weapons that use the "amount" property, like throwing knives or something).  

The amount of an item is now displayed in their InventoryPanel, unless there is only 1 item left in the stack. (Values of 0 and lower values are still drawn to make bugs easier to spot)
  
This PR also comes with a new "InventorySynchronizerComponent.update_inventory()" function that updates all panels as performantly as possible by reading the inventory directly. This should be considerably faster than adding/removing items individually since it only combs trough the panels once for all of the items.   

If this method can be queued to run once per frame once the inventory changes ( similar to queue_redraw() ), it should be a considerable speed up (and more reliable) for most inventory-related operations.
  
All items have an amount_max of 1 right now, except for potions who have a value of 6.