### PR TITLE
Adds a system for tooltips

### DIFF
--- a/Jdungeon.csproj
+++ b/Jdungeon.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.2.1">
+<Project Sdk="Godot.NET.Sdk/4.2.0">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/classes/Tooltip.gd
+++ b/classes/Tooltip.gd
@@ -1,0 +1,302 @@
+extends Node2D
+class_name Tooltip
+
+enum PopupDirections {
+	UP,
+	DOWN,
+	LEFT,
+	RIGHT,
+}
+const TAG_START: String = '[url="{0}"]'
+const TAG_END: String = "[/url]"
+
+const INVISIBLE_RECT: Rect2 = Rect2()
+
+signal visibility_update_required
+
+@export_category("Settings")
+@export var debug_mode: bool = false
+@export var allow_sub_tooltips: bool = true
+@export var pin_action: String = "ui_accept"
+
+@export_category("Appereance")
+@export var auto_choose_direction: bool = true
+
+@export var popup_dir: PopupDirections = PopupDirections.UP
+
+@export var text: String = "Placeholder":
+	set(value):
+		if label:
+			text = value
+			label.text = text
+			if not sub:
+				visibility_update_required.emit()
+
+@export var width: float = 120
+
+@export
+var sub_tooltips_to_display: Dictionary = {"help": "Every 'help' word will invoke this tooltip."}
+
+var target_hovered: bool:
+	set(val):
+		target_hovered = val
+		visibility_update_required.emit()
+
+var pinned: bool = false:
+	set(val):
+		pinned = val
+		visibility_update_required.emit()
+
+#var keyword_rect_dict: Dictionary
+var panel := Panel.new()
+var label := RichTextLabel.new()
+
+var sub_tooltip: Tooltip
+var sub: bool = false
+
+
+func _init() -> void:
+	hide()
+	visibility_update_required.connect(on_visibility_update_required)
+
+
+func _ready() -> void:
+	add_child(panel)
+	panel.add_child(label)
+	panel.clip_contents = false
+	panel.clip_children = CanvasItem.CLIP_CHILDREN_DISABLED
+	panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+	label.mouse_filter = Control.MOUSE_FILTER_PASS
+	label.set_anchors_preset(Control.PRESET_FULL_RECT)
+	label.text = text
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	label.meta_hover_started.connect(on_label_meta_hover_change.bind(true))
+	label.meta_hover_ended.connect(on_label_meta_hover_change.bind(false))
+	label.bbcode_enabled = true
+	label.clip_contents = false
+	label.clip_children = CanvasItem.CLIP_CHILDREN_DISABLED
+
+	if sub:
+		assert(get_parent() is RichTextLabel)
+		assert(get_parent().get_parent().get_parent() is Tooltip)
+
+		set_name("SubTooltip")
+		sub_tooltips_to_display.clear()
+		allow_sub_tooltips = false
+		auto_choose_direction = false
+		popup_dir = get_parent().get_parent().get_parent().popup_dir
+		update_size()
+		update_input_processing()
+		return
+
+	sub_tooltip = add_to_control(label, true)
+
+	pinned = pinned
+	connect_target_signals(get_target())
+
+	visibility_update_required.emit()
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed(pin_action) and not target_hovered:
+		pinned = false
+
+
+func connect_target_signals(target: Control):
+	if not target is Control:
+		return
+
+	target.gui_input.connect(on_target_gui_input)
+	target.mouse_entered.connect(on_mouse_hover_changed.bind(true))
+	target.mouse_exited.connect(on_mouse_hover_changed.bind(false))
+
+
+func get_target() -> Control:
+	return get_parent() if get_parent() is Control else null
+
+
+func get_auto_direction() -> PopupDirections:
+	var viewport_rect: Rect2 = get_viewport_rect()
+
+	var direction_dist_dict: Dictionary = {
+		PopupDirections.UP:
+		global_position.distance_to(
+			Vector2(viewport_rect.position.x + viewport_rect.size.x / 2, viewport_rect.position.y)
+		),
+		PopupDirections.DOWN:
+		global_position.distance_to(
+			Vector2(viewport_rect.position.x + viewport_rect.size.x / 2, viewport_rect.end.y)
+		),
+		PopupDirections.LEFT:
+		global_position.distance_to(
+			Vector2(viewport_rect.position.x, viewport_rect.position.y + viewport_rect.size.y / 2)
+		),
+		PopupDirections.RIGHT:
+		global_position.distance_to(
+			Vector2(viewport_rect.end.x, viewport_rect.position.y + viewport_rect.size.y / 2)
+		),
+	}
+
+	var closest_dir_to_border: PopupDirections
+	var smallest_value: float = INF
+
+	for direction: PopupDirections in direction_dist_dict:
+		var value: float = direction_dist_dict[direction]
+		if value < smallest_value:
+			closest_dir_to_border = direction
+			smallest_value = value
+
+	match closest_dir_to_border:
+		PopupDirections.UP:
+			return PopupDirections.DOWN
+		PopupDirections.DOWN:
+			return PopupDirections.UP
+		PopupDirections.LEFT:
+			return PopupDirections.RIGHT
+		PopupDirections.RIGHT:
+			return PopupDirections.LEFT
+		_:
+			push_error("Could not determine a direction automatically, returning the current one.")
+			return popup_dir
+
+
+func adjust_position(direction: PopupDirections):
+	var target_size: Vector2 = get_target().size
+
+	match direction:
+		PopupDirections.UP:
+			position = Vector2(target_size.x / 2, 0)
+			panel.grow_horizontal = Control.GROW_DIRECTION_BOTH
+			panel.grow_vertical = Control.GROW_DIRECTION_BEGIN
+
+		PopupDirections.DOWN:
+			position = Vector2(target_size.x / 2, target_size.y)
+			panel.grow_horizontal = Control.GROW_DIRECTION_BOTH
+			panel.grow_vertical = Control.GROW_DIRECTION_END
+
+		PopupDirections.LEFT:
+			position = Vector2(0, target_size.y / 2)
+			panel.grow_horizontal = Control.GROW_DIRECTION_BEGIN
+			panel.grow_vertical = Control.GROW_DIRECTION_BOTH
+
+		PopupDirections.RIGHT:
+			position = Vector2(target_size.x, target_size.y / 2)
+			panel.grow_horizontal = Control.GROW_DIRECTION_END
+			panel.grow_vertical = Control.GROW_DIRECTION_BOTH
+
+		_:
+			push_error("Invalid direction." + str(direction))
+
+
+func update_size():
+	var minimum_size: Vector2 = Vector2(width, label.get_content_height())
+	panel.custom_minimum_size = minimum_size
+	label.custom_minimum_size = minimum_size
+
+
+func update_input_processing():
+	set_process_input.call_deferred(pinned)
+	if allow_sub_tooltips and not sub:
+		label.mouse_filter = Control.MOUSE_FILTER_PASS
+	else:
+		label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		pass
+
+
+func update_rich_text():
+	var enriched_text: String
+	#var word_ranges: Array[Vector2i]
+
+	var words: PackedStringArray = text.split(" ")
+	var resulting_words: PackedStringArray = words.duplicate()
+	var index: int = 0
+	for word: String in words:
+		var tooltip_text: String = sub_tooltips_to_display.get(word, "")
+
+		if tooltip_text == "":
+			index += 1
+			continue
+
+		word = word.insert(0, TAG_START.format([tooltip_text]))
+		word = word.insert(word.length(), TAG_END)
+
+		resulting_words[index] = word
+
+		index += 1
+
+	enriched_text = " ".join(resulting_words)
+
+	label.parse_bbcode(enriched_text)
+
+
+#func update_keyword_rects():
+#var to_fill: Array[Rect2]
+#
+#for keyword: String in sub_tooltips_to_display.keys():
+#var last_find_index: int = 0
+#while last_find_index != -1:
+#last_find_index = label.text.find(keyword, last_find_index + 1)
+#
+#if last_find_index == -1:
+#continue
+#
+#var text_rect: Rect2 = calculate_word_position(label, last_find_index, last_find_index + keyword.length())
+#
+#to_fill.append(text_rect)
+#
+#keyword_rect_dict[keyword] = to_fill
+#print(keyword_rect_dict)
+
+
+func on_target_gui_input(event: InputEvent):
+	if event.is_action_pressed(pin_action):
+		pinned = !pinned
+
+
+func on_mouse_hover_changed(inside: bool):
+	target_hovered = inside
+
+
+func on_visibility_update_required():
+	if not is_node_ready():
+		await ready
+
+	if pinned:
+		show()
+	elif target_hovered:
+		show()
+	elif not target_hovered:
+		hide()
+
+	if auto_choose_direction:
+		popup_dir = get_auto_direction()
+
+	adjust_position(popup_dir)
+	update_size()
+	update_input_processing()
+	update_rich_text()
+	#update_keyword_rects()
+
+	queue_redraw()
+	label.queue_redraw()
+
+
+func on_label_meta_hover_change(meta, hovered: bool):
+	assert(meta is String)
+	if hovered:
+		sub_tooltip.text = meta
+		sub_tooltip.on_visibility_update_required()
+		sub_tooltip.show()
+	else:
+		sub_tooltip.hide()
+
+
+static func add_to_control(target: Control, sub: bool = false) -> Tooltip:
+	var new_tooltip := Tooltip.new()
+	new_tooltip.sub = sub
+	if sub:
+		target.add_child(new_tooltip, false, Node.INTERNAL_MODE_FRONT)
+	else:
+		target.add_child(new_tooltip)
+	return new_tooltip

--- a/classes/Tooltip.gd
+++ b/classes/Tooltip.gd
@@ -101,10 +101,10 @@ func _ready() -> void:
 
 	pinned = pinned
 	connect_target_signals(get_target())
-	
-	if get_target().get("theme"):
+
+	if get_target().get("theme") and theme == null:
 		theme = get_target().theme
-	
+
 	visibility_update_required.emit()
 
 

--- a/classes/Tooltip.gd
+++ b/classes/Tooltip.gd
@@ -26,7 +26,10 @@ signal visibility_update_required
 @export_category("Appereance")
 ## Will cause the tooltip to automatically choose a direction, ignores the popup_dir property while active.
 @export var auto_choose_direction: bool = true
-
+@export var theme: Theme:
+	set(val):
+		theme = val
+		panel.theme = theme
 @export var popup_dir: PopupDirections = PopupDirections.UP
 
 @export_multiline var text: String = "Placeholder":
@@ -98,7 +101,10 @@ func _ready() -> void:
 
 	pinned = pinned
 	connect_target_signals(get_target())
-
+	
+	if get_target().get("theme"):
+		theme = get_target().theme
+	
 	visibility_update_required.emit()
 
 

--- a/classes/Tooltip.gd
+++ b/classes/Tooltip.gd
@@ -15,7 +15,6 @@ const INVISIBLE_RECT: Rect2 = Rect2()
 signal visibility_update_required
 
 @export_category("Settings")
-@export var debug_mode: bool = false
 @export var allow_sub_tooltips: bool = true
 @export var pin_action: String = "ui_accept"
 

--- a/project.godot
+++ b/project.godot
@@ -167,6 +167,11 @@ j_continue={
 , Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(133, 6),"global_position":Vector2(137, 47),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
 ]
 }
+j_pin_tooltip={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":4,"position":Vector2(200, 19),"global_position":Vector2(204, 60),"factor":1.0,"button_index":3,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
 
 [internationalization]
 

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Jdungeon"
 run/main_scene="res://scenes/main/Main.tscn"
-config/features=PackedStringArray("4.2", "GL Compatibility")
+config/features=PackedStringArray("4.2", "C#", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [autoload]

--- a/scenes/player/gamemenu/GameMenu.tscn
+++ b/scenes/player/gamemenu/GameMenu.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://dssmk0m8xsvxf"]
+[gd_scene load_steps=4 format=3 uid="uid://dssmk0m8xsvxf"]
 
 [ext_resource type="Theme" uid="uid://dreboohjjcn2f" path="res://assets/themes/LoginPanelTheme.tres" id="1_yn42h"]
 [ext_resource type="Script" path="res://scenes/player/gamemenu/GameMenu.gd" id="2_dg6jl"]
+[ext_resource type="Script" path="res://classes/Tooltip.gd" id="3_l1agu"]
 
 [node name="GameMenu" type="PanelContainer"]
 anchors_preset = 15
@@ -51,6 +52,12 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "I'm Stuck Help!
 "
+
+[node name="Tooltip" type="Node2D" parent="MarginContainer/VBoxContainer/UnstuckButtonMarginContainer/UnstuckButton"]
+script = ExtResource("3_l1agu")
+pin_action = ""
+text = "Kills you instantly!
+This allows you to respawn at a proper, non-stuck location."
 
 [node name="QuitButtonMarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2

--- a/scenes/player/shop/Shop.tscn
+++ b/scenes/player/shop/Shop.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://dy1r3n0fpuneq"]
+[gd_scene load_steps=4 format=3 uid="uid://dy1r3n0fpuneq"]
 
 [ext_resource type="Script" path="res://scenes/player/shop/Shop.gd" id="1_wtd5h"]
 [ext_resource type="PackedScene" uid="uid://dws3rqcdwrf43" path="res://scenes/player/shop/ShopPanel.tscn" id="2_g77pf"]
+[ext_resource type="Script" path="res://classes/Tooltip.gd" id="3_5m8cc"]
 
 [node name="Shop" type="Panel"]
 offset_right = 269.0
@@ -120,3 +121,11 @@ offset_right = 20.0
 grow_horizontal = 2
 grow_vertical = 0
 metadata/_edit_lock_ = true
+
+[node name="Tooltip" type="Node2D" parent="."]
+script = ExtResource("3_5m8cc")
+text = "Right click on a shop item to buy it. The number shown depicts the cost in gold."
+sub_tooltips_to_display = {
+"gold": "Currency, duh.",
+"help": ""
+}

--- a/scenes/player/shortcutmenu/ShortcutMenu.tscn
+++ b/scenes/player/shortcutmenu/ShortcutMenu.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=10 format=3 uid="uid://d261xncd2la2h"]
+[gd_scene load_steps=11 format=3 uid="uid://d261xncd2la2h"]
 
 [ext_resource type="Script" path="res://scenes/player/shortcutmenu/ShortcutMenu.gd" id="1_faslu"]
 [ext_resource type="Texture2D" uid="uid://dqw4dsidoi5wf" path="res://assets/images/icons/789_Lorc_RPG_icons/scaled/Icon.5_85.png" id="1_ryg2n"]
 [ext_resource type="Texture2D" uid="uid://cwgm6exidxs08" path="res://assets/images/icons/789_Lorc_RPG_icons/scaled/Icon.3_83.png" id="2_481p7"]
+[ext_resource type="Script" path="res://classes/Tooltip.gd" id="3_01qcm"]
 [ext_resource type="Texture2D" uid="uid://ceoisjqj6obhb" path="res://assets/images/icons/789_Lorc_RPG_icons/scaled/Icon.6_94.png" id="3_upl7j"]
 [ext_resource type="Texture2D" uid="uid://5xbd6go3j1y6" path="res://assets/images/icons/789_Lorc_RPG_icons/scaled/Icon.6_37.png" id="4_pds2v"]
 
@@ -26,11 +27,23 @@ layout_mode = 2
 texture_normal = ExtResource("1_ryg2n")
 texture_pressed = SubResource("CanvasTexture_djxay")
 
+[node name="Tooltip" type="Node2D" parent="HBoxContainer/GameMenuButton"]
+script = ExtResource("3_01qcm")
+auto_choose_direction = false
+popup_dir = 1
+text = "Main menu."
+
 [node name="StatsButton" type="TextureButton" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 texture_normal = ExtResource("2_481p7")
 texture_pressed = SubResource("CanvasTexture_05pst")
+
+[node name="Tooltip" type="Node2D" parent="HBoxContainer/StatsButton"]
+script = ExtResource("3_01qcm")
+auto_choose_direction = false
+popup_dir = 1
+text = "Stats menu."
 
 [node name="EquipmentButton" type="TextureButton" parent="HBoxContainer"]
 unique_name_in_owner = true
@@ -38,8 +51,20 @@ layout_mode = 2
 texture_normal = ExtResource("3_upl7j")
 texture_pressed = SubResource("CanvasTexture_3vu0y")
 
+[node name="Tooltip" type="Node2D" parent="HBoxContainer/EquipmentButton"]
+script = ExtResource("3_01qcm")
+auto_choose_direction = false
+popup_dir = 1
+text = "Equipment menu."
+
 [node name="BagButton" type="TextureButton" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 texture_normal = ExtResource("4_pds2v")
 texture_pressed = SubResource("CanvasTexture_x2us5")
+
+[node name="Tooltip" type="Node2D" parent="HBoxContainer/BagButton"]
+script = ExtResource("3_01qcm")
+auto_choose_direction = false
+popup_dir = 1
+text = "Inventory."

--- a/scenes/player/statdisplay/StatDisplay.tscn
+++ b/scenes/player/statdisplay/StatDisplay.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://dirsk8pf0bxh5"]
+[gd_scene load_steps=3 format=3 uid="uid://dirsk8pf0bxh5"]
 
 [ext_resource type="Script" path="res://scenes/player/statdisplay/StatDisplay.gd" id="1_j3bvc"]
+[ext_resource type="Script" path="res://classes/Tooltip.gd" id="2_t5sva"]
 
 [node name="StatDisplay" type="Panel"]
 anchors_preset = -1
@@ -36,6 +37,10 @@ text = "Hit Points:"
 layout_mode = 2
 size_flags_horizontal = 3
 
+[node name="Tooltip" type="Node2D" parent="ScrollContainer/StatList/HPSplitContainer"]
+script = ExtResource("2_t5sva")
+text = "If this reaches 0, you die."
+
 [node name="HPMaxSplitContainer" type="SplitContainer" parent="ScrollContainer/StatList"]
 layout_mode = 2
 dragger_visibility = 1
@@ -61,6 +66,10 @@ text = "Energy:"
 [node name="Value" type="Label" parent="ScrollContainer/StatList/EnergySplitContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+
+[node name="Tooltip" type="Node2D" parent="ScrollContainer/StatList/EnergySplitContainer"]
+script = ExtResource("2_t5sva")
+text = "This is used to activate your skills. It recovers over time."
 
 [node name="EnergyMaxSplitContainer" type="SplitContainer" parent="ScrollContainer/StatList"]
 layout_mode = 2
@@ -127,6 +136,10 @@ text = "Needed experience:"
 layout_mode = 2
 size_flags_horizontal = 3
 
+[node name="Tooltip" type="Node2D" parent="ScrollContainer/StatList/ExperienceNeededSplitContainer"]
+script = ExtResource("2_t5sva")
+text = "Experience required for reaching the next level."
+
 [node name="AttackPowerMinSplitContainer" type="SplitContainer" parent="ScrollContainer/StatList"]
 layout_mode = 2
 dragger_visibility = 1
@@ -139,6 +152,10 @@ text = "Minimum Attack Power:"
 [node name="Value" type="Label" parent="ScrollContainer/StatList/AttackPowerMinSplitContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+
+[node name="Tooltip" type="Node2D" parent="ScrollContainer/StatList/AttackPowerMinSplitContainer"]
+script = ExtResource("2_t5sva")
+text = "The minimum base damage your attacks have."
 
 [node name="AttackPowerMaxSplitContainer" type="SplitContainer" parent="ScrollContainer/StatList"]
 layout_mode = 2
@@ -153,6 +170,10 @@ text = "Maximum Attack Power:"
 layout_mode = 2
 size_flags_horizontal = 3
 
+[node name="Tooltip" type="Node2D" parent="ScrollContainer/StatList/AttackPowerMaxSplitContainer"]
+script = ExtResource("2_t5sva")
+text = "The maximum base damage your attacks can have."
+
 [node name="DefenseSplitContainer" type="SplitContainer" parent="ScrollContainer/StatList"]
 layout_mode = 2
 dragger_visibility = 1
@@ -165,3 +186,9 @@ text = "Defense:"
 [node name="Value" type="Label" parent="ScrollContainer/StatList/DefenseSplitContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+
+[node name="Tooltip" type="Node2D" parent="ScrollContainer/StatList/DefenseSplitContainer"]
+script = ExtResource("2_t5sva")
+auto_choose_direction = false
+popup_dir = 2
+text = "Reduces incoming damage by this amount."


### PR DESCRIPTION
It is surprisingly difficult to find the position of text without direct access to TextSever RIDs (i tried for 3 days). So this will probably get reworked with Godot 4.3 which adds a method to do it for you.  
  
This tooltip is a Node2D that when added to any Control node, will automatically display a tooltip in the direction opposite to the closest edge of the screen (can be forced to be a set direction) with text set on the Tooltip node.    
It will use the parent's theme if it has any and no theme was defined on the tooltip yet.
~It also supports "sub tooltips" which cause yet another tooltip to spring from the original when a keyword is hovered with the mouse, explaining in further detail said keyword.~      
Sub tooltips have been delayed until Godot 4.3
    
Tooltips can be "pinned" which prevents them from moving or dissapearing by pressing the middle mouse button by default.
  
Added tooltips to some stats in the stats menu, the shop UI and the shortcuts at the top left of the screen.
  
TODO:

- [x] Add tooltips to some UI nodes  
- [x] Consider a component version that augments existing Labels
  
