### PR TITLE
 After Closing Bug Dialog. It will still opened by ESC Key

### DIFF
--- a/scenes/player/gamemenu/GameMenu.gd
+++ b/scenes/player/gamemenu/GameMenu.gd
@@ -41,16 +41,29 @@ func _input(event):
 	if self.visible:
 		#If the input happens outside the menu while it is open, hide it
 		if (event is InputEventMouseButton) and event.pressed:
-			var is_inside_menu: bool = (
-				Rect2(Vector2(position.x, position.y), Vector2(size.x, size.y))
-				. has_point(event.position)
-			)
+			var is_inside_menu: bool
+			if not is_instance_valid(sub_menu_reference):
+			#if is_instance_valid(sub_menu_reference):
+				#is_inside_menu = (
+					#Rect2(Vector2(sub_menu_reference.position.x,
+							#sub_menu_reference.position.y),
+						#Vector2(sub_menu_reference.size.x,
+							#sub_menu_reference.size.y))
+					#. has_point(event.position)
+				#)
+				#sub_menu_reference.queue_free()
+				#printt([sub_menu_reference.position, sub_menu_reference.size])
+			#else:
+				is_inside_menu = (
+					Rect2(Vector2(position.x, position.y), Vector2(size.x, size.y))
+					. has_point(event.position)
+				)
 
-			if not is_inside_menu:
-				self.hide()
-				JUI.above_ui = false
+				if not is_inside_menu:
+					self.hide()
+					JUI.above_ui = false
 
-				get_viewport().set_input_as_handled()
+					get_viewport().set_input_as_handled()
 
 
 #Also saves changes to disk.

--- a/scenes/player/gamemenu/reportbugmenu/ReportBugMenu.gd
+++ b/scenes/player/gamemenu/reportbugmenu/ReportBugMenu.gd
@@ -7,7 +7,8 @@ signal quit_pressed
 
 
 func _ready() -> void:
-	_quit_button.pressed.connect(emit_signal.bind("quit_pressed"))
+	#_quit_button.pressed.connect(emit_signal.bind("quit_pressed"))
+	_quit_button.pressed.connect(func(): quit_pressed.emit())
 	_link_button.pressed.connect(_on_link_button_pressed)
 
 


### PR DESCRIPTION
Fix: Issue #244
Solution 1: Only check click in region of mainmenu if no submenu is active
Solution 2 as comment: Check for active submenu and check the region for the submenu, queue_free() submenu if outside

Solution 1 is working

At Solution 2, i think it was not 100% working. 
Maybe the Dialog region is wrong

But you know your code better. Maybe there is a better point to fix this.

Please ignore the changes in ReportBugMenu.gd